### PR TITLE
Fix a bug in ucrSelector  

### DIFF
--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -4,6 +4,7 @@ Public Class ucrSelector
     Public CurrentReceiver As ucrReceiver
 
     Private Sub ucrdataselection_load(sender As Object, e As EventArgs) Handles MyBase.Load
+        lstAvailableVariable.Clear()
         frmMain.clsRInterface.FillListView(lstAvailableVariable)
     End Sub
 


### PR DESCRIPTION
This is done to avoid multiplication of variables inside the ucrSelectorAddRemove