### PR TITLE
Fixed regular sequence for numeric sequences

### DIFF
--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -222,11 +222,47 @@ Public Class RLink
 
     End Function
 
-    Public Function GetVariables(strLabel As String) As CharacterVector
+    Public Function RunInternalScriptGetValue(strScript As String) As SymbolicExpression
+        Dim expTemp As SymbolicExpression
 
-        Return Me.clsEngine.Evaluate(strLabel).AsCharacter
-
+        If clsEngine IsNot Nothing Then
+            Try
+                clsEngine.Evaluate("temp <- " & strScript)
+                expTemp = clsEngine.GetSymbol("temp")
+            Catch ex As Exception
+                'TODO what should be done here?
+                expTemp = Nothing
+            End Try
+        Else
+            expTemp = Nothing
+        End If
+        Return expTemp
     End Function
+
+    Public Function RunInternalScriptGetOutput(strScript As String) As CharacterVector
+        Dim chrTemp As CharacterVector
+        Dim expTemp As SymbolicExpression
+
+        expTemp = RunInternalScriptGetValue("capture.output(" & strScript & ")")
+        Try
+            chrTemp = expTemp.AsCharacter()
+        Catch ex As Exception
+            'TODO what should be done here?
+            chrTemp = Nothing
+        End Try
+        Return chrTemp
+    End Function
+
+    Public Sub RunInternalScript(strScript As String)
+        RunInternalScriptGetValue(strScript)
+        If clsEngine IsNot Nothing Then
+            Try
+                clsEngine.Evaluate(strScript)
+            Catch ex As Exception
+                'TODO what should be done here?
+            End Try
+        End If
+    End Sub
 
     Public Function GetDefaultDataFrameName(strPrefix As String, Optional iStartIndex As Integer = 1, Optional bIncludeIndex As Boolean = True) As String
         Dim strTemp As String

--- a/instat/dlgRegularSequence.designer.vb
+++ b/instat/dlgRegularSequence.designer.vb
@@ -30,7 +30,7 @@ Partial Class dlgRegularSequence
         Me.nudFrom = New System.Windows.Forms.NumericUpDown()
         Me.nudRepeatValues = New System.Windows.Forms.NumericUpDown()
         Me.dtpSelectorB = New System.Windows.Forms.DateTimePicker()
-        Me.nudInstepsOf = New System.Windows.Forms.NumericUpDown()
+        Me.nudInStepsOf = New System.Windows.Forms.NumericUpDown()
         Me.dtpSelectorA = New System.Windows.Forms.DateTimePicker()
         Me.chkDefineAsFactor = New System.Windows.Forms.CheckBox()
         Me.lblTimes1 = New System.Windows.Forms.Label()
@@ -42,17 +42,18 @@ Partial Class dlgRegularSequence
         Me.lblLength = New System.Windows.Forms.Label()
         Me.cmdRefreshPreview = New System.Windows.Forms.Button()
         Me.txtGetPreview = New System.Windows.Forms.RichTextBox()
+        Me.lblNewColumnName = New System.Windows.Forms.Label()
+        Me.ucrNewColumnName = New instat.ucrInputComboBox()
+        Me.ucrDataFrameLengthForRegularSequence = New instat.ucrDataFrameLength()
         Me.ucrSelectDataFrameRegularSequence = New instat.ucrDataFrame()
         Me.ucrBase = New instat.ucrButtons()
-        Me.UcrDataFrameLengthForRegularSequence = New instat.ucrDataFrameLength()
-        Me.UcrInputCboRegularSequence = New instat.ucrInputComboBox()
-        Me.lblNewColumnName = New System.Windows.Forms.Label()
+        Me.lblMessage = New System.Windows.Forms.Label()
         Me.grpSequenceType.SuspendLayout()
         Me.grpSequenceDefinition.SuspendLayout()
         CType(Me.nudTo, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.nudFrom, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.nudRepeatValues, System.ComponentModel.ISupportInitialize).BeginInit()
-        CType(Me.nudInstepsOf, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudInStepsOf, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'grpSequenceType
@@ -101,7 +102,7 @@ Partial Class dlgRegularSequence
         Me.grpSequenceDefinition.Controls.Add(Me.nudFrom)
         Me.grpSequenceDefinition.Controls.Add(Me.nudRepeatValues)
         Me.grpSequenceDefinition.Controls.Add(Me.dtpSelectorB)
-        Me.grpSequenceDefinition.Controls.Add(Me.nudInstepsOf)
+        Me.grpSequenceDefinition.Controls.Add(Me.nudInStepsOf)
         Me.grpSequenceDefinition.Controls.Add(Me.dtpSelectorA)
         Me.grpSequenceDefinition.Controls.Add(Me.chkDefineAsFactor)
         Me.grpSequenceDefinition.Controls.Add(Me.lblTimes1)
@@ -121,7 +122,7 @@ Partial Class dlgRegularSequence
         '
         'nudTo
         '
-        Me.nudTo.Location = New System.Drawing.Point(138, 48)
+        Me.nudTo.Location = New System.Drawing.Point(98, 46)
         Me.nudTo.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
         Me.nudTo.Name = "nudTo"
         Me.nudTo.Size = New System.Drawing.Size(51, 20)
@@ -129,7 +130,7 @@ Partial Class dlgRegularSequence
         '
         'nudFrom
         '
-        Me.nudFrom.Location = New System.Drawing.Point(138, 20)
+        Me.nudFrom.Location = New System.Drawing.Point(98, 20)
         Me.nudFrom.Maximum = New Decimal(New Integer() {10000, 0, 0, 0})
         Me.nudFrom.Name = "nudFrom"
         Me.nudFrom.Size = New System.Drawing.Size(51, 20)
@@ -138,9 +139,12 @@ Partial Class dlgRegularSequence
         'nudRepeatValues
         '
         Me.nudRepeatValues.Location = New System.Drawing.Point(98, 103)
+        Me.nudRepeatValues.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
+        Me.nudRepeatValues.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
         Me.nudRepeatValues.Name = "nudRepeatValues"
         Me.nudRepeatValues.Size = New System.Drawing.Size(44, 20)
         Me.nudRepeatValues.TabIndex = 12
+        Me.nudRepeatValues.Value = New Decimal(New Integer() {1, 0, 0, 0})
         '
         'dtpSelectorB
         '
@@ -149,12 +153,15 @@ Partial Class dlgRegularSequence
         Me.dtpSelectorB.Size = New System.Drawing.Size(87, 20)
         Me.dtpSelectorB.TabIndex = 5
         '
-        'nudInstepsOf
+        'nudInStepsOf
         '
-        Me.nudInstepsOf.Location = New System.Drawing.Point(98, 74)
-        Me.nudInstepsOf.Name = "nudInstepsOf"
-        Me.nudInstepsOf.Size = New System.Drawing.Size(47, 20)
-        Me.nudInstepsOf.TabIndex = 10
+        Me.nudInStepsOf.Location = New System.Drawing.Point(98, 74)
+        Me.nudInStepsOf.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
+        Me.nudInStepsOf.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.nudInStepsOf.Name = "nudInStepsOf"
+        Me.nudInStepsOf.Size = New System.Drawing.Size(47, 20)
+        Me.nudInStepsOf.TabIndex = 10
+        Me.nudInStepsOf.Value = New Decimal(New Integer() {1, 0, 0, 0})
         '
         'dtpSelectorA
         '
@@ -268,6 +275,31 @@ Partial Class dlgRegularSequence
         Me.txtGetPreview.TabIndex = 8
         Me.txtGetPreview.Text = ""
         '
+        'lblNewColumnName
+        '
+        Me.lblNewColumnName.AutoSize = True
+        Me.lblNewColumnName.Location = New System.Drawing.Point(12, 310)
+        Me.lblNewColumnName.Name = "lblNewColumnName"
+        Me.lblNewColumnName.Size = New System.Drawing.Size(98, 13)
+        Me.lblNewColumnName.TabIndex = 12
+        Me.lblNewColumnName.Tag = "New_Column_Name"
+        Me.lblNewColumnName.Text = "New Column Name"
+        '
+        'ucrNewColumnName
+        '
+        Me.ucrNewColumnName.Location = New System.Drawing.Point(122, 305)
+        Me.ucrNewColumnName.Name = "ucrNewColumnName"
+        Me.ucrNewColumnName.Size = New System.Drawing.Size(137, 25)
+        Me.ucrNewColumnName.TabIndex = 11
+        '
+        'ucrDataFrameLengthForRegularSequence
+        '
+        Me.ucrDataFrameLengthForRegularSequence.clsDataFrameSelector = Nothing
+        Me.ucrDataFrameLengthForRegularSequence.Location = New System.Drawing.Point(154, 25)
+        Me.ucrDataFrameLengthForRegularSequence.Name = "ucrDataFrameLengthForRegularSequence"
+        Me.ucrDataFrameLengthForRegularSequence.Size = New System.Drawing.Size(53, 23)
+        Me.ucrDataFrameLengthForRegularSequence.TabIndex = 10
+        '
         'ucrSelectDataFrameRegularSequence
         '
         Me.ucrSelectDataFrameRegularSequence.Location = New System.Drawing.Point(12, 9)
@@ -277,44 +309,28 @@ Partial Class dlgRegularSequence
         '
         'ucrBase
         '
-        Me.ucrBase.Location = New System.Drawing.Point(12, 296)
+        Me.ucrBase.Location = New System.Drawing.Point(7, 326)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(402, 55)
         Me.ucrBase.TabIndex = 9
         '
-        'UcrDataFrameLengthForRegularSequence
+        'lblMessage
         '
-        Me.UcrDataFrameLengthForRegularSequence.clsDataFrameSelector = Nothing
-        Me.UcrDataFrameLengthForRegularSequence.Location = New System.Drawing.Point(154, 25)
-        Me.UcrDataFrameLengthForRegularSequence.Name = "UcrDataFrameLengthForRegularSequence"
-        Me.UcrDataFrameLengthForRegularSequence.Size = New System.Drawing.Size(53, 23)
-        Me.UcrDataFrameLengthForRegularSequence.TabIndex = 10
-        '
-        'UcrInputCboRegularSequence
-        '
-        Me.UcrInputCboRegularSequence.Location = New System.Drawing.Point(122, 258)
-        Me.UcrInputCboRegularSequence.Name = "UcrInputCboRegularSequence"
-        Me.UcrInputCboRegularSequence.Size = New System.Drawing.Size(137, 25)
-        Me.UcrInputCboRegularSequence.TabIndex = 11
-        '
-        'lblNewColumnName
-        '
-        Me.lblNewColumnName.AutoSize = True
-        Me.lblNewColumnName.Location = New System.Drawing.Point(12, 263)
-        Me.lblNewColumnName.Name = "lblNewColumnName"
-        Me.lblNewColumnName.Size = New System.Drawing.Size(98, 13)
-        Me.lblNewColumnName.TabIndex = 12
-        Me.lblNewColumnName.Tag = "New_Column_Name"
-        Me.lblNewColumnName.Text = "New Column Name"
+        Me.lblMessage.AutoSize = True
+        Me.lblMessage.Location = New System.Drawing.Point(241, 258)
+        Me.lblMessage.Name = "lblMessage"
+        Me.lblMessage.Size = New System.Drawing.Size(0, 13)
+        Me.lblMessage.TabIndex = 13
         '
         'dlgRegularSequence
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(421, 351)
+        Me.ClientSize = New System.Drawing.Size(421, 393)
+        Me.Controls.Add(Me.lblMessage)
         Me.Controls.Add(Me.lblNewColumnName)
-        Me.Controls.Add(Me.UcrInputCboRegularSequence)
-        Me.Controls.Add(Me.UcrDataFrameLengthForRegularSequence)
+        Me.Controls.Add(Me.ucrNewColumnName)
+        Me.Controls.Add(Me.ucrDataFrameLengthForRegularSequence)
         Me.Controls.Add(Me.txtGetPreview)
         Me.Controls.Add(Me.cmdRefreshPreview)
         Me.Controls.Add(Me.grpSequenceDefinition)
@@ -337,7 +353,7 @@ Partial Class dlgRegularSequence
         CType(Me.nudTo, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.nudFrom, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.nudRepeatValues, System.ComponentModel.ISupportInitialize).EndInit()
-        CType(Me.nudInstepsOf, System.ComponentModel.ISupportInitialize).EndInit()
+        CType(Me.nudInStepsOf, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -364,8 +380,9 @@ Partial Class dlgRegularSequence
     Friend WithEvents nudTo As NumericUpDown
     Friend WithEvents nudFrom As NumericUpDown
     Friend WithEvents nudRepeatValues As NumericUpDown
-    Friend WithEvents nudInstepsOf As NumericUpDown
-    Friend WithEvents UcrDataFrameLengthForRegularSequence As ucrDataFrameLength
-    Friend WithEvents UcrInputCboRegularSequence As ucrInputComboBox
+    Friend WithEvents nudInStepsOf As NumericUpDown
+    Friend WithEvents ucrDataFrameLengthForRegularSequence As ucrDataFrameLength
+    Friend WithEvents ucrNewColumnName As ucrInputComboBox
     Friend WithEvents lblNewColumnName As Label
+    Friend WithEvents lblMessage As Label
 End Class

--- a/instat/dlgRegularSequence.designer.vb
+++ b/instat/dlgRegularSequence.designer.vb
@@ -40,14 +40,13 @@ Partial Class dlgRegularSequence
         Me.lblFrom = New System.Windows.Forms.Label()
         Me.lblPreview = New System.Windows.Forms.Label()
         Me.lblLength = New System.Windows.Forms.Label()
-        Me.cmdRefreshPreview = New System.Windows.Forms.Button()
         Me.txtGetPreview = New System.Windows.Forms.RichTextBox()
         Me.lblNewColumnName = New System.Windows.Forms.Label()
+        Me.txtMessage = New System.Windows.Forms.TextBox()
         Me.ucrNewColumnName = New instat.ucrInputComboBox()
         Me.ucrDataFrameLengthForRegularSequence = New instat.ucrDataFrameLength()
         Me.ucrSelectDataFrameRegularSequence = New instat.ucrDataFrame()
         Me.ucrBase = New instat.ucrButtons()
-        Me.lblMessage = New System.Windows.Forms.Label()
         Me.grpSequenceType.SuspendLayout()
         Me.grpSequenceDefinition.SuspendLayout()
         CType(Me.nudTo, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -101,9 +100,11 @@ Partial Class dlgRegularSequence
         Me.grpSequenceDefinition.Controls.Add(Me.nudTo)
         Me.grpSequenceDefinition.Controls.Add(Me.nudFrom)
         Me.grpSequenceDefinition.Controls.Add(Me.nudRepeatValues)
+        Me.grpSequenceDefinition.Controls.Add(Me.ucrDataFrameLengthForRegularSequence)
         Me.grpSequenceDefinition.Controls.Add(Me.dtpSelectorB)
         Me.grpSequenceDefinition.Controls.Add(Me.nudInStepsOf)
         Me.grpSequenceDefinition.Controls.Add(Me.dtpSelectorA)
+        Me.grpSequenceDefinition.Controls.Add(Me.lblLength)
         Me.grpSequenceDefinition.Controls.Add(Me.chkDefineAsFactor)
         Me.grpSequenceDefinition.Controls.Add(Me.lblTimes1)
         Me.grpSequenceDefinition.Controls.Add(Me.lblRepeatValues)
@@ -113,7 +114,7 @@ Partial Class dlgRegularSequence
         Me.grpSequenceDefinition.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.grpSequenceDefinition.Location = New System.Drawing.Point(12, 100)
         Me.grpSequenceDefinition.Name = "grpSequenceDefinition"
-        Me.grpSequenceDefinition.Size = New System.Drawing.Size(195, 152)
+        Me.grpSequenceDefinition.Size = New System.Drawing.Size(195, 180)
         Me.grpSequenceDefinition.TabIndex = 4
         Me.grpSequenceDefinition.TabStop = False
         Me.grpSequenceDefinition.Tag = "Sequence_definition"
@@ -123,7 +124,8 @@ Partial Class dlgRegularSequence
         'nudTo
         '
         Me.nudTo.Location = New System.Drawing.Point(98, 46)
-        Me.nudTo.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
+        Me.nudTo.Maximum = New Decimal(New Integer() {2147483647, 0, 0, 0})
+        Me.nudTo.Minimum = New Decimal(New Integer() {2147483647, 0, 0, -2147483648})
         Me.nudTo.Name = "nudTo"
         Me.nudTo.Size = New System.Drawing.Size(51, 20)
         Me.nudTo.TabIndex = 14
@@ -131,7 +133,8 @@ Partial Class dlgRegularSequence
         'nudFrom
         '
         Me.nudFrom.Location = New System.Drawing.Point(98, 20)
-        Me.nudFrom.Maximum = New Decimal(New Integer() {10000, 0, 0, 0})
+        Me.nudFrom.Maximum = New Decimal(New Integer() {2147483647, 0, 0, 0})
+        Me.nudFrom.Minimum = New Decimal(New Integer() {2147483647, 0, 0, -2147483648})
         Me.nudFrom.Name = "nudFrom"
         Me.nudFrom.Size = New System.Drawing.Size(51, 20)
         Me.nudFrom.TabIndex = 13
@@ -139,7 +142,7 @@ Partial Class dlgRegularSequence
         'nudRepeatValues
         '
         Me.nudRepeatValues.Location = New System.Drawing.Point(98, 103)
-        Me.nudRepeatValues.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
+        Me.nudRepeatValues.Maximum = New Decimal(New Integer() {2147483647, 0, 0, 0})
         Me.nudRepeatValues.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
         Me.nudRepeatValues.Name = "nudRepeatValues"
         Me.nudRepeatValues.Size = New System.Drawing.Size(44, 20)
@@ -156,7 +159,7 @@ Partial Class dlgRegularSequence
         'nudInStepsOf
         '
         Me.nudInStepsOf.Location = New System.Drawing.Point(98, 74)
-        Me.nudInStepsOf.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
+        Me.nudInStepsOf.Maximum = New Decimal(New Integer() {2147483647, 0, 0, 0})
         Me.nudInStepsOf.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
         Me.nudInStepsOf.Name = "nudInStepsOf"
         Me.nudInStepsOf.Size = New System.Drawing.Size(47, 20)
@@ -175,8 +178,7 @@ Partial Class dlgRegularSequence
         Me.chkDefineAsFactor.AutoSize = True
         Me.chkDefineAsFactor.Checked = True
         Me.chkDefineAsFactor.CheckState = System.Windows.Forms.CheckState.Checked
-        Me.chkDefineAsFactor.Enabled = False
-        Me.chkDefineAsFactor.Location = New System.Drawing.Point(12, 129)
+        Me.chkDefineAsFactor.Location = New System.Drawing.Point(15, 159)
         Me.chkDefineAsFactor.Name = "chkDefineAsFactor"
         Me.chkDefineAsFactor.Size = New System.Drawing.Size(101, 17)
         Me.chkDefineAsFactor.TabIndex = 11
@@ -240,36 +242,26 @@ Partial Class dlgRegularSequence
         'lblPreview
         '
         Me.lblPreview.AutoSize = True
-        Me.lblPreview.Location = New System.Drawing.Point(235, 51)
+        Me.lblPreview.Location = New System.Drawing.Point(235, 18)
         Me.lblPreview.Name = "lblPreview"
-        Me.lblPreview.Size = New System.Drawing.Size(45, 13)
+        Me.lblPreview.Size = New System.Drawing.Size(97, 13)
         Me.lblPreview.TabIndex = 7
         Me.lblPreview.Tag = "Preview"
-        Me.lblPreview.Text = "Preview"
+        Me.lblPreview.Text = "Sequence Preview"
         '
         'lblLength
         '
         Me.lblLength.AutoSize = True
-        Me.lblLength.Location = New System.Drawing.Point(157, 9)
+        Me.lblLength.Location = New System.Drawing.Point(12, 133)
         Me.lblLength.Name = "lblLength"
         Me.lblLength.Size = New System.Drawing.Size(40, 13)
         Me.lblLength.TabIndex = 1
         Me.lblLength.Tag = "Length"
         Me.lblLength.Text = "Length"
         '
-        'cmdRefreshPreview
-        '
-        Me.cmdRefreshPreview.Location = New System.Drawing.Point(238, 22)
-        Me.cmdRefreshPreview.Name = "cmdRefreshPreview"
-        Me.cmdRefreshPreview.Size = New System.Drawing.Size(176, 23)
-        Me.cmdRefreshPreview.TabIndex = 6
-        Me.cmdRefreshPreview.Tag = "Refresh_Preview"
-        Me.cmdRefreshPreview.Text = "Refresh Preview"
-        Me.cmdRefreshPreview.UseVisualStyleBackColor = True
-        '
         'txtGetPreview
         '
-        Me.txtGetPreview.Location = New System.Drawing.Point(238, 74)
+        Me.txtGetPreview.Location = New System.Drawing.Point(238, 34)
         Me.txtGetPreview.Name = "txtGetPreview"
         Me.txtGetPreview.Size = New System.Drawing.Size(171, 172)
         Me.txtGetPreview.TabIndex = 8
@@ -278,16 +270,26 @@ Partial Class dlgRegularSequence
         'lblNewColumnName
         '
         Me.lblNewColumnName.AutoSize = True
-        Me.lblNewColumnName.Location = New System.Drawing.Point(12, 310)
+        Me.lblNewColumnName.Location = New System.Drawing.Point(12, 297)
         Me.lblNewColumnName.Name = "lblNewColumnName"
         Me.lblNewColumnName.Size = New System.Drawing.Size(98, 13)
         Me.lblNewColumnName.TabIndex = 12
         Me.lblNewColumnName.Tag = "New_Column_Name"
         Me.lblNewColumnName.Text = "New Column Name"
         '
+        'txtMessage
+        '
+        Me.txtMessage.Enabled = False
+        Me.txtMessage.Location = New System.Drawing.Point(238, 218)
+        Me.txtMessage.Multiline = True
+        Me.txtMessage.Name = "txtMessage"
+        Me.txtMessage.ReadOnly = True
+        Me.txtMessage.Size = New System.Drawing.Size(171, 58)
+        Me.txtMessage.TabIndex = 14
+        '
         'ucrNewColumnName
         '
-        Me.ucrNewColumnName.Location = New System.Drawing.Point(122, 305)
+        Me.ucrNewColumnName.Location = New System.Drawing.Point(116, 293)
         Me.ucrNewColumnName.Name = "ucrNewColumnName"
         Me.ucrNewColumnName.Size = New System.Drawing.Size(137, 25)
         Me.ucrNewColumnName.TabIndex = 11
@@ -295,9 +297,9 @@ Partial Class dlgRegularSequence
         'ucrDataFrameLengthForRegularSequence
         '
         Me.ucrDataFrameLengthForRegularSequence.clsDataFrameSelector = Nothing
-        Me.ucrDataFrameLengthForRegularSequence.Location = New System.Drawing.Point(154, 25)
+        Me.ucrDataFrameLengthForRegularSequence.Location = New System.Drawing.Point(98, 130)
         Me.ucrDataFrameLengthForRegularSequence.Name = "ucrDataFrameLengthForRegularSequence"
-        Me.ucrDataFrameLengthForRegularSequence.Size = New System.Drawing.Size(53, 23)
+        Me.ucrDataFrameLengthForRegularSequence.Size = New System.Drawing.Size(51, 23)
         Me.ucrDataFrameLengthForRegularSequence.TabIndex = 10
         '
         'ucrSelectDataFrameRegularSequence
@@ -309,32 +311,21 @@ Partial Class dlgRegularSequence
         '
         'ucrBase
         '
-        Me.ucrBase.Location = New System.Drawing.Point(7, 326)
+        Me.ucrBase.Location = New System.Drawing.Point(7, 323)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(402, 55)
         Me.ucrBase.TabIndex = 9
-        '
-        'lblMessage
-        '
-        Me.lblMessage.AutoSize = True
-        Me.lblMessage.Location = New System.Drawing.Point(241, 258)
-        Me.lblMessage.Name = "lblMessage"
-        Me.lblMessage.Size = New System.Drawing.Size(0, 13)
-        Me.lblMessage.TabIndex = 13
         '
         'dlgRegularSequence
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(421, 393)
-        Me.Controls.Add(Me.lblMessage)
+        Me.ClientSize = New System.Drawing.Size(421, 390)
+        Me.Controls.Add(Me.txtMessage)
         Me.Controls.Add(Me.lblNewColumnName)
         Me.Controls.Add(Me.ucrNewColumnName)
-        Me.Controls.Add(Me.ucrDataFrameLengthForRegularSequence)
         Me.Controls.Add(Me.txtGetPreview)
-        Me.Controls.Add(Me.cmdRefreshPreview)
         Me.Controls.Add(Me.grpSequenceDefinition)
-        Me.Controls.Add(Me.lblLength)
         Me.Controls.Add(Me.lblPreview)
         Me.Controls.Add(Me.ucrSelectDataFrameRegularSequence)
         Me.Controls.Add(Me.ucrBase)
@@ -370,7 +361,6 @@ Partial Class dlgRegularSequence
     Friend WithEvents ucrSelectDataFrameRegularSequence As ucrDataFrame
     Friend WithEvents lblPreview As Label
     Friend WithEvents lblLength As Label
-    Friend WithEvents cmdRefreshPreview As Button
     Friend WithEvents lblTimes1 As Label
     Friend WithEvents lblRepeatValues As Label
     Friend WithEvents chkDefineAsFactor As CheckBox
@@ -384,5 +374,5 @@ Partial Class dlgRegularSequence
     Friend WithEvents ucrDataFrameLengthForRegularSequence As ucrDataFrameLength
     Friend WithEvents ucrNewColumnName As ucrInputComboBox
     Friend WithEvents lblNewColumnName As Label
-    Friend WithEvents lblMessage As Label
+    Friend WithEvents txtMessage As TextBox
 End Class

--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -14,15 +14,16 @@
 ' You should have received a copy of the GNU General Public License k
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 Imports instat.Translations
+Imports RDotNet
+
 Public Class dlgRegularSequence
     Dim bIsExtended As Boolean = False
     Public bFirstLoad As Boolean = True
+    Dim clsSeqFunction As New RFunction
+    Dim clsRepFunction As New RFunction
+
     Private Sub dlgRegularSequence_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-
         autoTranslate(Me)
-
-
-
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -34,13 +35,21 @@ Public Class dlgRegularSequence
     End Sub
 
     Private Sub InitialiseDialog()
-        ucrBase.clsRsyntax.SetFunction("seq")
+        clsSeqFunction.SetRCommand("seq")
+        clsRepFunction.SetRCommand("rep")
+        clsRepFunction.AddParameter("x", clsRFunctionParameter:=clsSeqFunction)
+        nudFrom.Minimum = Integer.MinValue
+        nudFrom.Maximum = Integer.MaxValue
+        nudTo.Minimum = Integer.MinValue
+        nudTo.Maximum = Integer.MaxValue
+        nudInStepsOf.Maximum = Integer.MaxValue
+        nudRepeatValues.Maximum = Integer.MaxValue
         ucrBase.iHelpTopicID = 30
-        UcrDataFrameLengthForRegularSequence.SetDataFrameSelector(ucrSelectDataFrameRegularSequence)
-        UcrInputCboRegularSequence.SetPrefix("Regular")
-        UcrInputCboRegularSequence.SetItemsTypeAsColumns()
-        UcrInputCboRegularSequence.SetDefaultTypeAsColumn()
-        UcrInputCboRegularSequence.SetDataFrameSelector(ucrSelectDataFrameRegularSequence)
+        ucrDataFrameLengthForRegularSequence.SetDataFrameSelector(ucrSelectDataFrameRegularSequence)
+        ucrNewColumnName.SetPrefix("Regular")
+        ucrNewColumnName.SetItemsTypeAsColumns()
+        ucrNewColumnName.SetDefaultTypeAsColumn()
+        ucrNewColumnName.SetDataFrameSelector(ucrSelectDataFrameRegularSequence)
     End Sub
 
     Private Sub SetDefaults()
@@ -48,6 +57,10 @@ Public Class dlgRegularSequence
         rdoDates.Checked = False
         ucrSelectDataFrameRegularSequence.Reset()
         ucrSelectDataFrameRegularSequence.Focus()
+        nudFrom.Value = 1
+        nudTo.Value = ucrSelectDataFrameRegularSequence.iDataFrameLength
+        nudInStepsOf.Value = 1
+        CheckSequenceLength()
     End Sub
 
     Private Sub ReopenDialog()
@@ -57,29 +70,21 @@ Public Class dlgRegularSequence
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         TestOKEnabled()
-
-
     End Sub
 
     Private Sub TestOKEnabled()
-        If rdoNumeric.Checked = True Then
-            If nudFrom.Text <> "" And nudTo.Text <> "" Then
+        If rdoNumeric.Checked Then
+            If nudFrom.Text <> "" AndAlso nudTo.Text <> "" AndAlso nudInStepsOf.Text <> "" AndAlso nudRepeatValues.Text <> "" Then
                 ucrBase.OKEnabled(True)
             Else
                 ucrBase.OKEnabled(False)
             End If
-        ElseIf rdoDates.Checked = True Then
-
+        ElseIf rdoDates.Checked Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
         End If
     End Sub
-
-    'Private Sub cmdRefreshPreview_Click(sender As Object, e As EventArgs) Handles cmdRefreshPreview.Click
-    '    frmMain.clsRLink.RunScript(ucrBase.clsRsyntax.clsBaseFunction.ToScript(), 2)
-    '    txtGetPreview.Refresh()
-    'End Sub
 
     Private Sub grpSequenceType_CheckedChanged(sender As Object, e As EventArgs) Handles rdoDates.CheckedChanged, rdoNumeric.CheckedChanged
         If rdoNumeric.Checked Then
@@ -87,46 +92,110 @@ Public Class dlgRegularSequence
             nudTo.Visible = True
             dtpSelectorA.Visible = False
             dtpSelectorB.Visible = False
-            nudRepeatValues.Enabled = False
         Else
             dtpSelectorA.Visible = True
             dtpSelectorB.Visible = True
             nudFrom.Visible = False
             nudTo.Visible = False
         End If
+        CheckSequenceLength()
         TestOKEnabled()
     End Sub
 
-    Private Sub nudInstepsOf_ValueChanged(sender As Object, e As EventArgs) Handles nudInstepsOf.ValueChanged
-        ucrBase.clsRsyntax.AddParameter("by", nudInstepsOf.Value)
-    End Sub
-
-    Private Sub nudRepeatValues_ValueChanged(sender As Object, e As EventArgs) Handles nudRepeatValues.ValueChanged
-        If rdoDates.Checked Then
-            ucrBase.clsRsyntax.AddParameter("length.out", "NULL")
+    Private Sub nudInstepsOf_ValueChanged(sender As Object, e As EventArgs) Handles nudInStepsOf.ValueChanged
+        If nudInStepsOf.Text <> "" Then
+            If (nudInStepsOf.Value = 1 AndAlso frmMain.clsInstatOptions.bIncludeRDefaultParameters) OrElse nudInStepsOf.Value <> 1 Then
+                clsSeqFunction.AddParameter("by", nudInStepsOf.Value)
+            Else
+                clsSeqFunction.RemoveParameterByName("by")
+            End If
         Else
-            ucrBase.clsRsyntax.AddParameter("length.out", nudRepeatValues.Value)
+            clsSeqFunction.RemoveParameterByName("by")
         End If
-
+        CheckSequenceLength()
     End Sub
 
-    Private Sub nudFrom_ValueChanged(sender As Object, e As EventArgs) Handles nudFrom.ValueChanged
-        ucrBase.clsRsyntax.AddParameter("from", nudFrom.Value)
+    Private Sub nudRepeatValues_ValueChanged(sender As Object, e As EventArgs) Handles nudRepeatValues.TextChanged
+        SetRepeatProperties()
     End Sub
 
-    Private Sub nudTo_ValueChanged(sender As Object, e As EventArgs) Handles nudTo.ValueChanged
-        ucrBase.clsRsyntax.AddParameter("to", nudTo.Value)
+    Private Sub SetRepeatProperties()
+        If nudRepeatValues.Text <> "" AndAlso nudRepeatValues.Value > 1 Then
+            ucrBase.clsRsyntax.SetBaseRFunction(clsRepFunction)
+            clsRepFunction.AddParameter("each", nudRepeatValues.Value)
+        Else
+            ucrBase.clsRsyntax.SetBaseRFunction(clsSeqFunction)
+        End If
+        CheckSequenceLength()
+    End Sub
+
+    Private Sub nudFrom_ValueChanged(sender As Object, e As EventArgs) Handles nudFrom.TextChanged
+        If nudFrom.Text <> "" Then
+            clsSeqFunction.AddParameter("from", nudFrom.Value)
+        Else
+            clsSeqFunction.RemoveParameterByName("from")
+        End If
+        CheckSequenceLength()
+    End Sub
+
+    Private Sub nudTo_ValueChanged(sender As Object, e As EventArgs) Handles nudTo.TextChanged
+        If nudTo.Text <> "" Then
+            clsSeqFunction.AddParameter("to", nudTo.Value)
+        Else
+            clsSeqFunction.RemoveParameterByName("to")
+        End If
+        CheckSequenceLength()
     End Sub
 
     Private Sub dtpSelectorA_ValueChanged(sender As Object, e As EventArgs) Handles dtpSelectorA.ValueChanged
         ucrBase.clsRsyntax.AddParameter("from", "as.Date('" & Format(dtpSelectorA.Value, "yyyy/MM/dd") & "')")
+        CheckSequenceLength()
     End Sub
 
     Private Sub dtpSelectorB_ValueChanged(sender As Object, e As EventArgs) Handles dtpSelectorB.ValueChanged
         ucrBase.clsRsyntax.AddParameter("to", "as.Date('" & Format(dtpSelectorB.Value, "yyyy/MM/dd") & "')")
+        CheckSequenceLength()
     End Sub
 
-    Private Sub UcrInputCboRegularSequence_NameChanged() Handles UcrInputCboRegularSequence.NameChanged
-        ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=UcrInputCboRegularSequence.GetText, strTempDataframe:=ucrSelectDataFrameRegularSequence.cboAvailableDataFrames.Text, strTempColumn:=UcrInputCboRegularSequence.GetText)
+    Private Sub ucrInputCboRegularSequence_NameChanged() Handles ucrNewColumnName.NameChanged
+        ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=ucrNewColumnName.GetText, strTempDataframe:=ucrSelectDataFrameRegularSequence.cboAvailableDataFrames.Text, strTempColumn:=ucrNewColumnName.GetText)
+    End Sub
+
+    Private Sub ucrSelectDataFrameRegularSequence_DataFrameChanged(sender As Object, e As EventArgs, strPrevDataFrame As String) Handles ucrSelectDataFrameRegularSequence.DataFrameChanged
+        nudTo.Value = ucrSelectDataFrameRegularSequence.iDataFrameLength
+        SetRepeatProperties()
+        nudFrom.Value = 1
+        nudTo.Value = ucrSelectDataFrameRegularSequence.iDataFrameLength
+        CheckSequenceLength()
+    End Sub
+
+    Private Sub CheckSequenceLength()
+        Dim iLength As Integer
+        Dim vecSequence As NumericVector
+        Dim strRCommand As String
+        lblMessage.Text = ""
+        Try
+            strRCommand = ucrBase.clsRsyntax.clsBaseFunction.ToScript()
+            vecSequence = frmMain.clsRLink.clsEngine.Evaluate(strRCommand).AsNumeric
+            iLength = vecSequence.Length
+            If iLength <> ucrSelectDataFrameRegularSequence.iDataFrameLength Then
+                ucrBase.clsRsyntax.SetBaseRFunction(clsRepFunction)
+                clsRepFunction.AddParameter("length.out", ucrSelectDataFrameRegularSequence.iDataFrameLength)
+                strRCommand = ucrBase.clsRsyntax.clsBaseFunction.ToScript()
+                vecSequence = frmMain.clsRLink.clsEngine.Evaluate(strRCommand).AsNumeric
+                If iLength < ucrSelectDataFrameRegularSequence.iDataFrameLength Then
+                    lblMessage.Text = "Sequence has been extended by repeating to match the length of the dataframe."
+                ElseIf iLength > ucrSelectDataFrameRegularSequence.iDataFrameLength Then
+                    lblMessage.Text = "Sequence has been truncated to match the length of the dataframe."
+                End If
+            Else
+                clsRepFunction.RemoveParameterByName("length.out")
+                lblMessage.Text = "Sequence matches the length of the dataframe."
+            End If
+            txtGetPreview.Text = vecSequence.ToString()
+        Catch ex As Exception
+            txtGetPreview.Text = ""
+            lblMessage.Text = "No preview avaiable"
+        End Try
     End Sub
 End Class


### PR DESCRIPTION
Dates option disabled since still needs further work. Discussions on dialog design and preview window needed and desired functionality e.g. from = 1, to = 10, by = 1 produces `rep(x = seq(from = 1, to = 10) , length.out = 36)` instead of `seq(from = 1, to = 10, length.out = 36)`. Should both be possible?