### PR TITLE
Amended a few small bugs for the following dialogs:

### DIFF
--- a/instat/dlgPermuteColumn.vb
+++ b/instat/dlgPermuteColumn.vb
@@ -65,10 +65,10 @@ Public Class dlgPermuteColumn
     End Sub
 
     Private Sub TestOkEnabled()
-        If ucrReceiverPermuteRows.IsEmpty Then
-            ucrBase.OKEnabled(False)
-        Else
+        If Not ucrReceiverPermuteRows.IsEmpty AndAlso Not ucrInputPermuteRows.IsEmpty Then
             ucrBase.OKEnabled(True)
+        Else
+            ucrBase.OKEnabled(False)
         End If
     End Sub
 
@@ -101,6 +101,7 @@ Public Class dlgPermuteColumn
 
     Private Sub ucrInputPermuteRows_nameChanged() Handles ucrInputPermuteRows.NameChanged
         ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=ucrInputPermuteRows.GetText, strTempDataframe:=ucrPermuteRowsSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrInputPermuteRows.GetText, bAssignToIsPrefix:=True)
+        TestOkEnabled()
     End Sub
 
     Private Sub ucrPermuteRowsSelector_DataFrameChanged() Handles ucrPermuteRowsSelector.DataFrameChanged

--- a/instat/dlgPolynomials.vb
+++ b/instat/dlgPolynomials.vb
@@ -35,7 +35,7 @@ Public Class dlgPolynomials
     End Sub
 
     Private Sub TestOKEnabled()
-        If ucrReceiverPolynomial.IsEmpty() = False And nudDegree.Text <> "" Then
+        If Not ucrReceiverPolynomial.IsEmpty() AndAlso nudDegree.Text <> "" AndAlso Not ucrInputPolynomial.IsEmpty Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
@@ -74,6 +74,7 @@ Public Class dlgPolynomials
 
     Private Sub ucrInputPolynomial_NameChanged() Handles ucrInputPolynomial.NameChanged
         ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=ucrInputPolynomial.GetText, strTempDataframe:=ucrSelectorForPolynomial.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrInputPolynomial.GetText, bAssignToIsPrefix:=True)
+        TestOKEnabled()
     End Sub
 
     Private Sub ucrReceiverPolynomial_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverPolynomial.SelectionChanged

--- a/instat/dlgRandomSample.designer.vb
+++ b/instat/dlgRandomSample.designer.vb
@@ -42,7 +42,7 @@ Partial Class dlgRandomSample
         'lblSampleSize
         '
         Me.lblSampleSize.AutoSize = True
-        Me.lblSampleSize.Location = New System.Drawing.Point(255, 85)
+        Me.lblSampleSize.Location = New System.Drawing.Point(256, 85)
         Me.lblSampleSize.Name = "lblSampleSize"
         Me.lblSampleSize.Size = New System.Drawing.Size(65, 13)
         Me.lblSampleSize.TabIndex = 10
@@ -52,7 +52,7 @@ Partial Class dlgRandomSample
         'lblNumberofSamples
         '
         Me.lblNumberofSamples.AutoSize = True
-        Me.lblNumberofSamples.Location = New System.Drawing.Point(255, 57)
+        Me.lblNumberofSamples.Location = New System.Drawing.Point(256, 57)
         Me.lblNumberofSamples.Name = "lblNumberofSamples"
         Me.lblNumberofSamples.Size = New System.Drawing.Size(99, 13)
         Me.lblNumberofSamples.TabIndex = 10
@@ -71,7 +71,7 @@ Partial Class dlgRandomSample
         '
         'nudNumberOfSamples
         '
-        Me.nudNumberOfSamples.Location = New System.Drawing.Point(361, 50)
+        Me.nudNumberOfSamples.Location = New System.Drawing.Point(361, 54)
         Me.nudNumberOfSamples.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
         Me.nudNumberOfSamples.Name = "nudNumberOfSamples"
         Me.nudNumberOfSamples.Size = New System.Drawing.Size(35, 20)
@@ -80,7 +80,7 @@ Partial Class dlgRandomSample
         '
         'nudSeed
         '
-        Me.nudSeed.Location = New System.Drawing.Point(332, 22)
+        Me.nudSeed.Location = New System.Drawing.Point(331, 23)
         Me.nudSeed.Name = "nudSeed"
         Me.nudSeed.Size = New System.Drawing.Size(35, 20)
         Me.nudSeed.TabIndex = 18
@@ -88,7 +88,7 @@ Partial Class dlgRandomSample
         'chkSetSeed
         '
         Me.chkSetSeed.AutoSize = True
-        Me.chkSetSeed.Location = New System.Drawing.Point(255, 25)
+        Me.chkSetSeed.Location = New System.Drawing.Point(258, 25)
         Me.chkSetSeed.Name = "chkSetSeed"
         Me.chkSetSeed.Size = New System.Drawing.Size(70, 17)
         Me.chkSetSeed.TabIndex = 19
@@ -108,6 +108,7 @@ Partial Class dlgRandomSample
         '
         'ucrNewColumnName
         '
+        Me.ucrNewColumnName.IsReadOnly = False
         Me.ucrNewColumnName.Location = New System.Drawing.Point(134, 221)
         Me.ucrNewColumnName.Name = "ucrNewColumnName"
         Me.ucrNewColumnName.Size = New System.Drawing.Size(145, 21)
@@ -115,6 +116,7 @@ Partial Class dlgRandomSample
         '
         'ucrPrefixNewColumns
         '
+        Me.ucrPrefixNewColumns.IsReadOnly = False
         Me.ucrPrefixNewColumns.Location = New System.Drawing.Point(134, 222)
         Me.ucrPrefixNewColumns.Name = "ucrPrefixNewColumns"
         Me.ucrPrefixNewColumns.Size = New System.Drawing.Size(145, 21)
@@ -123,13 +125,14 @@ Partial Class dlgRandomSample
         'ucrSampleSize
         '
         Me.ucrSampleSize.clsDataFrameSelector = Nothing
-        Me.ucrSampleSize.Location = New System.Drawing.Point(331, 75)
+        Me.ucrSampleSize.Location = New System.Drawing.Point(331, 81)
         Me.ucrSampleSize.Name = "ucrSampleSize"
         Me.ucrSampleSize.Size = New System.Drawing.Size(53, 23)
         Me.ucrSampleSize.TabIndex = 13
         '
         'ucrSelectorRandomSamples
         '
+        Me.ucrSelectorRandomSamples.bUseCurrentFilter = False
         Me.ucrSelectorRandomSamples.Location = New System.Drawing.Point(10, 10)
         Me.ucrSelectorRandomSamples.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorRandomSamples.Name = "ucrSelectorRandomSamples"

--- a/instat/dlgRandomSample.vb
+++ b/instat/dlgRandomSample.vb
@@ -48,6 +48,7 @@ Public Class dlgRandomSample
         ucrNewColumnName.SetDefaultTypeAsColumn()
         ucrNewColumnName.SetDataFrameSelector(ucrSelectorRandomSamples)
         ucrNewColumnName.SetValidationTypeAsRVariable()
+        ucrPrefixNewColumns.SetValidationTypeAsRVariable()
     End Sub
 
     Private Sub SetDefaults()
@@ -170,4 +171,5 @@ Public Class dlgRandomSample
         SetSeedParameters()
         TestOKEnabled()
     End Sub
+
 End Class

--- a/instat/dlgRegularSequence.vb
+++ b/instat/dlgRegularSequence.vb
@@ -80,14 +80,18 @@ Public Class dlgRegularSequence
     End Sub
 
     Private Sub TestOKEnabled()
-        If rdoNumeric.Checked Then
-            If nudFrom.Text <> "" AndAlso nudTo.Text <> "" AndAlso nudInStepsOf.Text <> "" AndAlso nudRepeatValues.Text <> "" AndAlso ucrDataFrameLengthForRegularSequence.clsDataFrameSelector.cboAvailableDataFrames.Text <> "" Then
+        If Not ucrNewColumnName.IsEmpty Then
+            If rdoNumeric.Checked Then
+                If nudFrom.Text <> "" AndAlso nudTo.Text <> "" AndAlso nudInStepsOf.Text <> "" AndAlso nudRepeatValues.Text <> "" AndAlso ucrDataFrameLengthForRegularSequence.clsDataFrameSelector.cboAvailableDataFrames.Text <> "" Then
+                    ucrBase.OKEnabled(True)
+                Else
+                    ucrBase.OKEnabled(False)
+                End If
+            ElseIf rdoDates.Checked Then
                 ucrBase.OKEnabled(True)
             Else
                 ucrBase.OKEnabled(False)
             End If
-        ElseIf rdoDates.Checked Then
-            ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
         End If
@@ -119,9 +123,10 @@ Public Class dlgRegularSequence
         TestOKEnabled()
     End Sub
 
-    Private Sub nudInstepsOf_ValueChanged(sender As Object, e As EventArgs) Handles nudInStepsOf.ValueChanged
+    Private Sub nudInstepsOf_TextChanged(sender As Object, e As EventArgs) Handles nudInStepsOf.TextChanged
         SetInStepsOfParameter()
         CheckSequenceLength()
+        TestOKEnabled()
     End Sub
 
     Private Sub SetInStepsOfParameter()
@@ -143,8 +148,9 @@ Public Class dlgRegularSequence
             clsSeqFunction.RemoveParameterByName("by")
         End If
     End Sub
-    Private Sub nudRepeatValues_ValueChanged(sender As Object, e As EventArgs) Handles nudRepeatValues.TextChanged
+    Private Sub nudRepeatValues_TextChanged(sender As Object, e As EventArgs) Handles nudRepeatValues.TextChanged
         SetRepeatProperties()
+        TestOKEnabled()
     End Sub
 
     Private Sub SetRepeatProperties()
@@ -165,9 +171,10 @@ Public Class dlgRegularSequence
         CheckSequenceLength()
     End Sub
 
-    Private Sub nudFrom_ValueChanged(sender As Object, e As EventArgs) Handles nudFrom.TextChanged
+    Private Sub nudFrom_TextChanged(sender As Object, e As EventArgs) Handles nudFrom.TextChanged
         SetFromParameter()
         CheckSequenceLength()
+        TestOKEnabled()
     End Sub
 
     Private Sub SetFromParameter()
@@ -182,9 +189,10 @@ Public Class dlgRegularSequence
         End If
     End Sub
 
-    Private Sub nudTo_ValueChanged(sender As Object, e As EventArgs) Handles nudTo.TextChanged
+    Private Sub nudTo_TextChanged(sender As Object, e As EventArgs) Handles nudTo.TextChanged
         SetToParameter()
         CheckSequenceLength()
+        TestOKEnabled()
     End Sub
 
     Private Sub SetToParameter()
@@ -211,6 +219,7 @@ Public Class dlgRegularSequence
 
     Private Sub ucrInputCboRegularSequence_NameChanged() Handles ucrNewColumnName.NameChanged
         SetAssignTo()
+        TestOKEnabled()
     End Sub
 
     Private Sub SetAssignTo()

--- a/instat/dlgRowStats.vb
+++ b/instat/dlgRowStats.vb
@@ -41,7 +41,7 @@ Public Class dlgRowStats
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrReceiverForRowStatistics.IsEmpty Then
+        If Not ucrReceiverForRowStatistics.IsEmpty AndAlso Not ucrInputcboRowSummary.IsEmpty Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)
@@ -106,5 +106,6 @@ Public Class dlgRowStats
 
     Private Sub ucrInputcboRowSummary_NameChanged() Handles ucrInputcboRowSummary.NameChanged
         ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=ucrInputcboRowSummary.GetText, strTempDataframe:=ucrSelectorForRowStats.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrInputcboRowSummary.GetText)
+        TestOKEnabled()
     End Sub
 End Class


### PR DESCRIPTION
Polynomials:
TestOKEnabled is now False for if there is no column name

Row Statistics:
TestOKEnabled is now False for if there is no column name

Regular Sequence
TestOKEnabled is now False for if there is no column name
TestOKEnabled is now False for if notthing is selected for the nud: from, to, instepsof and repeatvalues

Generate Random Sample
Set Validation Type as R Variable for the Prefix

Permute Column Dialogs
TestOKEnabled is now False for if there is no column name
