### PR TITLE
Amended Dialog Designs for:

### DIFF
--- a/instat/dlgColumnStats.vb
+++ b/instat/dlgColumnStats.vb
@@ -55,6 +55,7 @@ Public Class dlgColumnStats
         ucrReceiverByFactor.Selector = ucrSelectorForColumnStatistics
         ucrReceiverSelectedVariables.SetMeAsReceiver()
         ucrReceiverSelectedVariables.SetIncludedDataTypes({"numeric"})
+        ' only allow numeric variables in the first receiver? 
         ucrReceiverByFactor.SetIncludedDataTypes({"factor"}) 'This needs to change
         ucrBase.iHelpTopicID = 64
         clsRColumnStats.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$calculate_summary")

--- a/instat/dlgCombine.Designer.vb
+++ b/instat/dlgCombine.Designer.vb
@@ -22,7 +22,6 @@ Partial Class dlgCombine
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgCombine))
         Me.ucrSelectorCombineFactors = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrFactorsReceiver = New instat.ucrReceiverMultiple()
         Me.lblFactors = New System.Windows.Forms.Label()
@@ -36,54 +35,74 @@ Partial Class dlgCombine
         '
         Me.ucrSelectorCombineFactors.bShowHiddenColumns = False
         Me.ucrSelectorCombineFactors.bUseCurrentFilter = False
-        resources.ApplyResources(Me.ucrSelectorCombineFactors, "ucrSelectorCombineFactors")
+        Me.ucrSelectorCombineFactors.Location = New System.Drawing.Point(9, 9)
+        Me.ucrSelectorCombineFactors.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorCombineFactors.Name = "ucrSelectorCombineFactors"
+        Me.ucrSelectorCombineFactors.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorCombineFactors.TabIndex = 6
         '
         'ucrFactorsReceiver
         '
-        resources.ApplyResources(Me.ucrFactorsReceiver, "ucrFactorsReceiver")
+        Me.ucrFactorsReceiver.Location = New System.Drawing.Point(271, 60)
+        Me.ucrFactorsReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrFactorsReceiver.Name = "ucrFactorsReceiver"
         Me.ucrFactorsReceiver.Selector = Nothing
+        Me.ucrFactorsReceiver.Size = New System.Drawing.Size(120, 100)
+        Me.ucrFactorsReceiver.TabIndex = 5
         '
         'lblFactors
         '
-        resources.ApplyResources(Me.lblFactors, "lblFactors")
+        Me.lblFactors.Location = New System.Drawing.Point(270, 35)
         Me.lblFactors.Name = "lblFactors"
+        Me.lblFactors.Size = New System.Drawing.Size(100, 23)
+        Me.lblFactors.TabIndex = 4
         Me.lblFactors.Tag = "Factors"
+        Me.lblFactors.Text = "Factors:"
         '
         'chkDropUnusedLevels
         '
-        resources.ApplyResources(Me.chkDropUnusedLevels, "chkDropUnusedLevels")
+        Me.chkDropUnusedLevels.Location = New System.Drawing.Point(271, 165)
         Me.chkDropUnusedLevels.Name = "chkDropUnusedLevels"
+        Me.chkDropUnusedLevels.Size = New System.Drawing.Size(127, 24)
+        Me.chkDropUnusedLevels.TabIndex = 3
         Me.chkDropUnusedLevels.Tag = "Drop_Unused_Levels "
+        Me.chkDropUnusedLevels.Text = "Drop Unused Levels"
         Me.chkDropUnusedLevels.UseVisualStyleBackColor = True
         '
         'ucrInputColName
         '
         Me.ucrInputColName.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputColName, "ucrInputColName")
+        Me.ucrInputColName.Location = New System.Drawing.Point(119, 196)
         Me.ucrInputColName.Name = "ucrInputColName"
+        Me.ucrInputColName.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputColName.TabIndex = 2
         '
         'lblNewColumnName
         '
-        resources.ApplyResources(Me.lblNewColumnName, "lblNewColumnName")
+        Me.lblNewColumnName.Location = New System.Drawing.Point(12, 199)
         Me.lblNewColumnName.Name = "lblNewColumnName"
+        Me.lblNewColumnName.Size = New System.Drawing.Size(107, 23)
+        Me.lblNewColumnName.TabIndex = 1
         Me.lblNewColumnName.Tag = "New_Column_Name"
+        Me.lblNewColumnName.Text = "New Column Name:"
         '
         'ucrBase
         '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Location = New System.Drawing.Point(12, 221)
         Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 0
         '
         'dlgCombine
         '
-        resources.ApplyResources(Me, "$this")
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(415, 285)
+        Me.Controls.Add(Me.lblFactors)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.lblNewColumnName)
         Me.Controls.Add(Me.ucrInputColName)
         Me.Controls.Add(Me.chkDropUnusedLevels)
-        Me.Controls.Add(Me.lblFactors)
         Me.Controls.Add(Me.ucrFactorsReceiver)
         Me.Controls.Add(Me.ucrSelectorCombineFactors)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
@@ -92,7 +111,6 @@ Partial Class dlgCombine
         Me.Name = "dlgCombine"
         Me.Tag = "Combine_Factors"
         Me.ResumeLayout(False)
-        Me.PerformLayout()
 
     End Sub
     Friend WithEvents ucrSelectorCombineFactors As ucrSelectorByDataFrameAddRemove

--- a/instat/dlgCombine.vb
+++ b/instat/dlgCombine.vb
@@ -94,4 +94,5 @@ Public Class dlgCombine
     Private Sub ucrSelectorCombineFactors_DataFrameChanged() Handles ucrSelectorCombineFactors.DataFrameChanged
         ucrBase.clsRsyntax.SetAssignTo(strAssignToName:=ucrInputColName.GetText, strTempDataframe:=ucrSelectorCombineFactors.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempColumn:=ucrInputColName.GetText)
     End Sub
+
 End Class

--- a/instat/dlgName.Designer.vb
+++ b/instat/dlgName.Designer.vb
@@ -22,7 +22,6 @@ Partial Class dlgName
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgName))
         Me.lblName = New System.Windows.Forms.Label()
         Me.lblCurrentName = New System.Windows.Forms.Label()
         Me.ucrInputNewName = New instat.ucrInputTextBox()
@@ -33,56 +32,72 @@ Partial Class dlgName
         '
         'lblName
         '
-        resources.ApplyResources(Me.lblName, "lblName")
+        Me.lblName.Location = New System.Drawing.Point(255, 66)
         Me.lblName.Name = "lblName"
+        Me.lblName.Size = New System.Drawing.Size(100, 23)
+        Me.lblName.TabIndex = 4
         Me.lblName.Tag = "New_Name"
+        Me.lblName.Text = "New Name:"
         '
         'lblCurrentName
         '
-        resources.ApplyResources(Me.lblCurrentName, "lblCurrentName")
+        Me.lblCurrentName.Location = New System.Drawing.Point(255, 15)
         Me.lblCurrentName.Name = "lblCurrentName"
+        Me.lblCurrentName.Size = New System.Drawing.Size(100, 23)
+        Me.lblCurrentName.TabIndex = 1
+        Me.lblCurrentName.Text = "Current Name:"
         '
         'ucrInputNewName
         '
         Me.ucrInputNewName.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputNewName, "ucrInputNewName")
+        Me.ucrInputNewName.Location = New System.Drawing.Point(257, 83)
         Me.ucrInputNewName.Name = "ucrInputNewName"
+        Me.ucrInputNewName.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputNewName.TabIndex = 0
         '
         'ucrSelectVariables
         '
         Me.ucrSelectVariables.bShowHiddenColumns = False
         Me.ucrSelectVariables.bUseCurrentFilter = False
-        resources.ApplyResources(Me.ucrSelectVariables, "ucrSelectVariables")
+        Me.ucrSelectVariables.Location = New System.Drawing.Point(10, 10)
+        Me.ucrSelectVariables.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectVariables.Name = "ucrSelectVariables"
+        Me.ucrSelectVariables.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectVariables.TabIndex = 2
         '
         'ucrBase
         '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Location = New System.Drawing.Point(10, 203)
         Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 3
         '
         'ucrReceiverName
         '
-        resources.ApplyResources(Me.ucrReceiverName, "ucrReceiverName")
+        Me.ucrReceiverName.Location = New System.Drawing.Point(257, 33)
+        Me.ucrReceiverName.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverName.Name = "ucrReceiverName"
         Me.ucrReceiverName.Selector = Nothing
+        Me.ucrReceiverName.Size = New System.Drawing.Size(137, 20)
+        Me.ucrReceiverName.TabIndex = 5
         '
         'dlgName
         '
-        resources.ApplyResources(Me, "$this")
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(417, 263)
+        Me.Controls.Add(Me.ucrReceiverName)
         Me.Controls.Add(Me.ucrInputNewName)
         Me.Controls.Add(Me.lblCurrentName)
         Me.Controls.Add(Me.ucrSelectVariables)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.lblName)
-        Me.Controls.Add(Me.ucrReceiverName)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgName"
         Me.Tag = "Rename_Data_Column"
         Me.ResumeLayout(False)
-        Me.PerformLayout()
 
     End Sub
     Friend WithEvents ucrReceiverName As ucrReceiverSingle

--- a/instat/dlgRenameDescriptive.Designer.vb
+++ b/instat/dlgRenameDescriptive.Designer.vb
@@ -22,7 +22,6 @@ Partial Class dlgRenameDescriptive
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgRenameDescriptive))
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorForRenameObject = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrReceiverCurrentName = New instat.ucrReceiverSingle()
@@ -33,48 +32,65 @@ Partial Class dlgRenameDescriptive
         '
         'ucrBase
         '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Location = New System.Drawing.Point(10, 207)
         Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 5
         '
         'ucrSelectorForRenameObject
         '
         Me.ucrSelectorForRenameObject.bShowHiddenColumns = False
         Me.ucrSelectorForRenameObject.bUseCurrentFilter = False
-        resources.ApplyResources(Me.ucrSelectorForRenameObject, "ucrSelectorForRenameObject")
+        Me.ucrSelectorForRenameObject.Location = New System.Drawing.Point(10, 10)
+        Me.ucrSelectorForRenameObject.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorForRenameObject.Name = "ucrSelectorForRenameObject"
+        Me.ucrSelectorForRenameObject.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorForRenameObject.TabIndex = 4
         '
         'ucrReceiverCurrentName
         '
-        resources.ApplyResources(Me.ucrReceiverCurrentName, "ucrReceiverCurrentName")
+        Me.ucrReceiverCurrentName.Location = New System.Drawing.Point(265, 33)
+        Me.ucrReceiverCurrentName.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverCurrentName.Name = "ucrReceiverCurrentName"
         Me.ucrReceiverCurrentName.Selector = Nothing
+        Me.ucrReceiverCurrentName.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverCurrentName.TabIndex = 3
         '
         'lblCurrentName
         '
-        resources.ApplyResources(Me.lblCurrentName, "lblCurrentName")
+        Me.lblCurrentName.Location = New System.Drawing.Point(263, 15)
         Me.lblCurrentName.Name = "lblCurrentName"
+        Me.lblCurrentName.Size = New System.Drawing.Size(100, 23)
+        Me.lblCurrentName.TabIndex = 2
         Me.lblCurrentName.Tag = "Current_Name"
+        Me.lblCurrentName.Text = "Current Name:"
         '
         'lblNewName
         '
-        resources.ApplyResources(Me.lblNewName, "lblNewName")
+        Me.lblNewName.Location = New System.Drawing.Point(263, 79)
         Me.lblNewName.Name = "lblNewName"
+        Me.lblNewName.Size = New System.Drawing.Size(100, 23)
+        Me.lblNewName.TabIndex = 1
         Me.lblNewName.Tag = "New_Name"
+        Me.lblNewName.Text = "New Name:"
         '
         'ucrInputNewName
         '
         Me.ucrInputNewName.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputNewName, "ucrInputNewName")
+        Me.ucrInputNewName.Location = New System.Drawing.Point(265, 95)
         Me.ucrInputNewName.Name = "ucrInputNewName"
+        Me.ucrInputNewName.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputNewName.TabIndex = 0
         '
         'dlgRenameDescriptive
         '
-        resources.ApplyResources(Me, "$this")
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(417, 264)
+        Me.Controls.Add(Me.ucrReceiverCurrentName)
         Me.Controls.Add(Me.ucrInputNewName)
         Me.Controls.Add(Me.lblNewName)
         Me.Controls.Add(Me.lblCurrentName)
-        Me.Controls.Add(Me.ucrReceiverCurrentName)
         Me.Controls.Add(Me.ucrSelectorForRenameObject)
         Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
@@ -83,7 +99,6 @@ Partial Class dlgRenameDescriptive
         Me.Name = "dlgRenameDescriptive"
         Me.Tag = "Rename_Object"
         Me.ResumeLayout(False)
-        Me.PerformLayout()
 
     End Sub
 

--- a/instat/dlgSplitText.Designer.vb
+++ b/instat/dlgSplitText.Designer.vb
@@ -22,7 +22,6 @@ Partial Class dlgSplitText
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgSplitText))
         Me.lblSelectedFactor = New System.Windows.Forms.Label()
         Me.lblSplitBy = New System.Windows.Forms.Label()
         Me.lblNewColumnNames = New System.Windows.Forms.Label()
@@ -38,69 +37,96 @@ Partial Class dlgSplitText
         '
         'lblSelectedFactor
         '
-        resources.ApplyResources(Me.lblSelectedFactor, "lblSelectedFactor")
+        Me.lblSelectedFactor.Location = New System.Drawing.Point(275, 43)
         Me.lblSelectedFactor.Name = "lblSelectedFactor"
+        Me.lblSelectedFactor.Size = New System.Drawing.Size(140, 23)
+        Me.lblSelectedFactor.TabIndex = 7
         Me.lblSelectedFactor.Tag = "Selected_Factor"
+        Me.lblSelectedFactor.Text = "Selected Factor:"
         '
         'lblSplitBy
         '
-        resources.ApplyResources(Me.lblSplitBy, "lblSplitBy")
+        Me.lblSplitBy.Location = New System.Drawing.Point(275, 90)
         Me.lblSplitBy.Name = "lblSplitBy"
+        Me.lblSplitBy.Size = New System.Drawing.Size(140, 23)
+        Me.lblSplitBy.TabIndex = 6
         Me.lblSplitBy.Tag = ""
+        Me.lblSplitBy.Text = "Split by:"
         '
         'lblNewColumnNames
         '
-        resources.ApplyResources(Me.lblNewColumnNames, "lblNewColumnNames")
+        Me.lblNewColumnNames.Location = New System.Drawing.Point(10, 202)
         Me.lblNewColumnNames.Name = "lblNewColumnNames"
+        Me.lblNewColumnNames.Size = New System.Drawing.Size(161, 23)
+        Me.lblNewColumnNames.TabIndex = 5
         Me.lblNewColumnNames.Tag = ""
+        Me.lblNewColumnNames.Text = "Prefix for New Columns:"
         '
         'lblNumberofPiecesToReturn
         '
-        resources.ApplyResources(Me.lblNumberofPiecesToReturn, "lblNumberofPiecesToReturn")
+        Me.lblNumberofPiecesToReturn.Location = New System.Drawing.Point(273, 140)
         Me.lblNumberofPiecesToReturn.Name = "lblNumberofPiecesToReturn"
+        Me.lblNumberofPiecesToReturn.Size = New System.Drawing.Size(149, 23)
+        Me.lblNumberofPiecesToReturn.TabIndex = 4
         Me.lblNumberofPiecesToReturn.Tag = "Number_of_Pieces_to_Return"
+        Me.lblNumberofPiecesToReturn.Text = "Number of Pieces to Return:"
         '
         'nudN
         '
-        resources.ApplyResources(Me.nudN, "nudN")
+        Me.nudN.Location = New System.Drawing.Point(276, 157)
         Me.nudN.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
         Me.nudN.Name = "nudN"
+        Me.nudN.Size = New System.Drawing.Size(37, 20)
+        Me.nudN.TabIndex = 3
         Me.nudN.Value = New Decimal(New Integer() {1, 0, 0, 0})
         '
         'ucrInputPattern
         '
         Me.ucrInputPattern.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputPattern, "ucrInputPattern")
+        Me.ucrInputPattern.Location = New System.Drawing.Point(276, 60)
         Me.ucrInputPattern.Name = "ucrInputPattern"
+        Me.ucrInputPattern.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputPattern.TabIndex = 0
         '
         'ucrReceiverSplitTextColumn
         '
-        resources.ApplyResources(Me.ucrReceiverSplitTextColumn, "ucrReceiverSplitTextColumn")
+        Me.ucrReceiverSplitTextColumn.Location = New System.Drawing.Point(276, 106)
+        Me.ucrReceiverSplitTextColumn.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSplitTextColumn.Name = "ucrReceiverSplitTextColumn"
         Me.ucrReceiverSplitTextColumn.Selector = Nothing
+        Me.ucrReceiverSplitTextColumn.Size = New System.Drawing.Size(137, 20)
+        Me.ucrReceiverSplitTextColumn.TabIndex = 1
         '
         'ucrInputColumnsIntoText
         '
         Me.ucrInputColumnsIntoText.IsReadOnly = False
-        resources.ApplyResources(Me.ucrInputColumnsIntoText, "ucrInputColumnsIntoText")
+        Me.ucrInputColumnsIntoText.Location = New System.Drawing.Point(131, 200)
         Me.ucrInputColumnsIntoText.Name = "ucrInputColumnsIntoText"
+        Me.ucrInputColumnsIntoText.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputColumnsIntoText.TabIndex = 2
         '
         'ucrSelectorSplitTextColumn
         '
         Me.ucrSelectorSplitTextColumn.bShowHiddenColumns = False
         Me.ucrSelectorSplitTextColumn.bUseCurrentFilter = False
-        resources.ApplyResources(Me.ucrSelectorSplitTextColumn, "ucrSelectorSplitTextColumn")
+        Me.ucrSelectorSplitTextColumn.Location = New System.Drawing.Point(10, 10)
+        Me.ucrSelectorSplitTextColumn.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorSplitTextColumn.Name = "ucrSelectorSplitTextColumn"
+        Me.ucrSelectorSplitTextColumn.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorSplitTextColumn.TabIndex = 8
         '
         'ucrBase
         '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Location = New System.Drawing.Point(10, 230)
         Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 9
         '
         'dlgSplitText
         '
-        resources.ApplyResources(Me, "$this")
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(421, 288)
         Me.Controls.Add(Me.ucrInputPattern)
         Me.Controls.Add(Me.ucrReceiverSplitTextColumn)
         Me.Controls.Add(Me.ucrInputColumnsIntoText)
@@ -118,7 +144,6 @@ Partial Class dlgSplitText
         Me.Tag = "Split_Text_Column"
         CType(Me.nudN, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
-        Me.PerformLayout()
 
     End Sub
 

--- a/instat/dlgSplitText.vb
+++ b/instat/dlgSplitText.vb
@@ -108,4 +108,5 @@ Public Class dlgSplitText
         End If
         TestOKEnabled()
     End Sub
+
 End Class

--- a/instat/dlgTransformText.Designer.vb
+++ b/instat/dlgTransformText.Designer.vb
@@ -42,37 +42,37 @@ Partial Class dlgTransformText
         Me.lblFirstWord = New System.Windows.Forms.Label()
         Me.nudFirstWord = New System.Windows.Forms.NumericUpDown()
         Me.grpParameters = New System.Windows.Forms.GroupBox()
+        Me.pnlTrim = New System.Windows.Forms.Panel()
+        Me.rdoBothTrim = New System.Windows.Forms.RadioButton()
+        Me.rdoLeftTrim = New System.Windows.Forms.RadioButton()
+        Me.rdoRightTrim = New System.Windows.Forms.RadioButton()
+        Me.pnlPad = New System.Windows.Forms.Panel()
+        Me.rdoBothPad = New System.Windows.Forms.RadioButton()
+        Me.rdoLeftPad = New System.Windows.Forms.RadioButton()
+        Me.rdoRightPad = New System.Windows.Forms.RadioButton()
+        Me.ucrInputSeparator = New instat.ucrInputComboBox()
         Me.lblTo = New System.Windows.Forms.Label()
         Me.lblPad = New System.Windows.Forms.Label()
-        Me.chkLastWord = New System.Windows.Forms.CheckBox()
-        Me.rdoBothPad = New System.Windows.Forms.RadioButton()
-        Me.rdoBothTrim = New System.Windows.Forms.RadioButton()
-        Me.rdoLeftPad = New System.Windows.Forms.RadioButton()
-        Me.rdoLeftTrim = New System.Windows.Forms.RadioButton()
-        Me.rdoRightPad = New System.Windows.Forms.RadioButton()
-        Me.rdoRightTrim = New System.Windows.Forms.RadioButton()
-        Me.nudWidth = New System.Windows.Forms.NumericUpDown()
-        Me.lblWidth = New System.Windows.Forms.Label()
-        Me.ucrInputSeparator = New instat.ucrInputComboBox()
         Me.ucrReceiverLastWord = New instat.ucrReceiverSingle()
+        Me.chkLastWord = New System.Windows.Forms.CheckBox()
         Me.ucrReceiverFirstWord = New instat.ucrReceiverSingle()
         Me.ucrInputTo = New instat.ucrInputComboBox()
         Me.ucrInputPad = New instat.ucrInputComboBox()
+        Me.nudWidth = New System.Windows.Forms.NumericUpDown()
+        Me.lblWidth = New System.Windows.Forms.Label()
         Me.ucrInputPrefixForNewColumn = New instat.ucrInputComboBox()
         Me.ucrReceiverTransformText = New instat.ucrReceiverSingle()
         Me.ucrSelectorForTransformText = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.pnlPad = New System.Windows.Forms.Panel()
-        Me.pnlTrim = New System.Windows.Forms.Panel()
         Me.grpOperation.SuspendLayout()
         CType(Me.nudTo, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.nudFrom, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.nudLastWord, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.nudFirstWord, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.grpParameters.SuspendLayout()
-        CType(Me.nudWidth, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.pnlPad.SuspendLayout()
         Me.pnlTrim.SuspendLayout()
+        Me.pnlPad.SuspendLayout()
+        CType(Me.nudWidth, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'lblColumnToTransform
@@ -228,7 +228,7 @@ Partial Class dlgTransformText
         Me.lblSeparator.Name = "lblSeparator"
         Me.lblSeparator.Size = New System.Drawing.Size(53, 13)
         Me.lblSeparator.TabIndex = 18
-        Me.lblSeparator.Text = "Seperator"
+        Me.lblSeparator.Text = "Separator"
         '
         'nudLastWord
         '
@@ -297,6 +297,100 @@ Partial Class dlgTransformText
         Me.grpParameters.TabStop = False
         Me.grpParameters.Text = "Options"
         '
+        'pnlTrim
+        '
+        Me.pnlTrim.Controls.Add(Me.rdoBothTrim)
+        Me.pnlTrim.Controls.Add(Me.rdoLeftTrim)
+        Me.pnlTrim.Controls.Add(Me.rdoRightTrim)
+        Me.pnlTrim.Location = New System.Drawing.Point(11, 15)
+        Me.pnlTrim.Name = "pnlTrim"
+        Me.pnlTrim.Size = New System.Drawing.Size(154, 24)
+        Me.pnlTrim.TabIndex = 42
+        '
+        'rdoBothTrim
+        '
+        Me.rdoBothTrim.AutoSize = True
+        Me.rdoBothTrim.Location = New System.Drawing.Point(104, 3)
+        Me.rdoBothTrim.Name = "rdoBothTrim"
+        Me.rdoBothTrim.Size = New System.Drawing.Size(47, 17)
+        Me.rdoBothTrim.TabIndex = 37
+        Me.rdoBothTrim.TabStop = True
+        Me.rdoBothTrim.Text = "Both"
+        Me.rdoBothTrim.UseVisualStyleBackColor = True
+        '
+        'rdoLeftTrim
+        '
+        Me.rdoLeftTrim.AutoSize = True
+        Me.rdoLeftTrim.Location = New System.Drawing.Point(3, 3)
+        Me.rdoLeftTrim.Name = "rdoLeftTrim"
+        Me.rdoLeftTrim.Size = New System.Drawing.Size(43, 17)
+        Me.rdoLeftTrim.TabIndex = 35
+        Me.rdoLeftTrim.TabStop = True
+        Me.rdoLeftTrim.Text = "Left"
+        Me.rdoLeftTrim.UseVisualStyleBackColor = True
+        '
+        'rdoRightTrim
+        '
+        Me.rdoRightTrim.AutoSize = True
+        Me.rdoRightTrim.Location = New System.Drawing.Point(48, 3)
+        Me.rdoRightTrim.Name = "rdoRightTrim"
+        Me.rdoRightTrim.Size = New System.Drawing.Size(50, 17)
+        Me.rdoRightTrim.TabIndex = 36
+        Me.rdoRightTrim.TabStop = True
+        Me.rdoRightTrim.Text = "Right"
+        Me.rdoRightTrim.UseVisualStyleBackColor = True
+        '
+        'pnlPad
+        '
+        Me.pnlPad.Controls.Add(Me.rdoBothPad)
+        Me.pnlPad.Controls.Add(Me.rdoLeftPad)
+        Me.pnlPad.Controls.Add(Me.rdoRightPad)
+        Me.pnlPad.Location = New System.Drawing.Point(11, 16)
+        Me.pnlPad.Name = "pnlPad"
+        Me.pnlPad.Size = New System.Drawing.Size(154, 24)
+        Me.pnlPad.TabIndex = 41
+        '
+        'rdoBothPad
+        '
+        Me.rdoBothPad.AutoSize = True
+        Me.rdoBothPad.Location = New System.Drawing.Point(104, 3)
+        Me.rdoBothPad.Name = "rdoBothPad"
+        Me.rdoBothPad.Size = New System.Drawing.Size(47, 17)
+        Me.rdoBothPad.TabIndex = 40
+        Me.rdoBothPad.TabStop = True
+        Me.rdoBothPad.Text = "Both"
+        Me.rdoBothPad.UseVisualStyleBackColor = True
+        '
+        'rdoLeftPad
+        '
+        Me.rdoLeftPad.AutoSize = True
+        Me.rdoLeftPad.Location = New System.Drawing.Point(3, 3)
+        Me.rdoLeftPad.Name = "rdoLeftPad"
+        Me.rdoLeftPad.Size = New System.Drawing.Size(43, 17)
+        Me.rdoLeftPad.TabIndex = 38
+        Me.rdoLeftPad.TabStop = True
+        Me.rdoLeftPad.Text = "Left"
+        Me.rdoLeftPad.UseVisualStyleBackColor = True
+        '
+        'rdoRightPad
+        '
+        Me.rdoRightPad.AutoSize = True
+        Me.rdoRightPad.Location = New System.Drawing.Point(51, 3)
+        Me.rdoRightPad.Name = "rdoRightPad"
+        Me.rdoRightPad.Size = New System.Drawing.Size(50, 17)
+        Me.rdoRightPad.TabIndex = 39
+        Me.rdoRightPad.TabStop = True
+        Me.rdoRightPad.Text = "Right"
+        Me.rdoRightPad.UseVisualStyleBackColor = True
+        '
+        'ucrInputSeparator
+        '
+        Me.ucrInputSeparator.IsReadOnly = False
+        Me.ucrInputSeparator.Location = New System.Drawing.Point(69, 105)
+        Me.ucrInputSeparator.Name = "ucrInputSeparator"
+        Me.ucrInputSeparator.Size = New System.Drawing.Size(73, 25)
+        Me.ucrInputSeparator.TabIndex = 17
+        '
         'lblTo
         '
         Me.lblTo.AutoSize = True
@@ -315,6 +409,15 @@ Partial Class dlgTransformText
         Me.lblPad.TabIndex = 14
         Me.lblPad.Text = "Pad"
         '
+        'ucrReceiverLastWord
+        '
+        Me.ucrReceiverLastWord.Location = New System.Drawing.Point(148, 76)
+        Me.ucrReceiverLastWord.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverLastWord.Name = "ucrReceiverLastWord"
+        Me.ucrReceiverLastWord.Selector = Nothing
+        Me.ucrReceiverLastWord.Size = New System.Drawing.Size(107, 26)
+        Me.ucrReceiverLastWord.TabIndex = 27
+        '
         'chkLastWord
         '
         Me.chkLastWord.AutoSize = True
@@ -325,71 +428,30 @@ Partial Class dlgTransformText
         Me.chkLastWord.Text = "Or Column"
         Me.chkLastWord.UseVisualStyleBackColor = True
         '
-        'rdoBothPad
+        'ucrReceiverFirstWord
         '
-        Me.rdoBothPad.AutoSize = True
-        Me.rdoBothPad.Location = New System.Drawing.Point(104, 3)
-        Me.rdoBothPad.Name = "rdoBothPad"
-        Me.rdoBothPad.Size = New System.Drawing.Size(47, 17)
-        Me.rdoBothPad.TabIndex = 40
-        Me.rdoBothPad.TabStop = True
-        Me.rdoBothPad.Text = "Both"
-        Me.rdoBothPad.UseVisualStyleBackColor = True
+        Me.ucrReceiverFirstWord.Location = New System.Drawing.Point(148, 36)
+        Me.ucrReceiverFirstWord.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFirstWord.Name = "ucrReceiverFirstWord"
+        Me.ucrReceiverFirstWord.Selector = Nothing
+        Me.ucrReceiverFirstWord.Size = New System.Drawing.Size(107, 26)
+        Me.ucrReceiverFirstWord.TabIndex = 13
         '
-        'rdoBothTrim
+        'ucrInputTo
         '
-        Me.rdoBothTrim.AutoSize = True
-        Me.rdoBothTrim.Location = New System.Drawing.Point(104, 3)
-        Me.rdoBothTrim.Name = "rdoBothTrim"
-        Me.rdoBothTrim.Size = New System.Drawing.Size(47, 17)
-        Me.rdoBothTrim.TabIndex = 37
-        Me.rdoBothTrim.TabStop = True
-        Me.rdoBothTrim.Text = "Both"
-        Me.rdoBothTrim.UseVisualStyleBackColor = True
+        Me.ucrInputTo.IsReadOnly = False
+        Me.ucrInputTo.Location = New System.Drawing.Point(32, 19)
+        Me.ucrInputTo.Name = "ucrInputTo"
+        Me.ucrInputTo.Size = New System.Drawing.Size(73, 25)
+        Me.ucrInputTo.TabIndex = 8
         '
-        'rdoLeftPad
+        'ucrInputPad
         '
-        Me.rdoLeftPad.AutoSize = True
-        Me.rdoLeftPad.Location = New System.Drawing.Point(3, 3)
-        Me.rdoLeftPad.Name = "rdoLeftPad"
-        Me.rdoLeftPad.Size = New System.Drawing.Size(43, 17)
-        Me.rdoLeftPad.TabIndex = 38
-        Me.rdoLeftPad.TabStop = True
-        Me.rdoLeftPad.Text = "Left"
-        Me.rdoLeftPad.UseVisualStyleBackColor = True
-        '
-        'rdoLeftTrim
-        '
-        Me.rdoLeftTrim.AutoSize = True
-        Me.rdoLeftTrim.Location = New System.Drawing.Point(3, 3)
-        Me.rdoLeftTrim.Name = "rdoLeftTrim"
-        Me.rdoLeftTrim.Size = New System.Drawing.Size(43, 17)
-        Me.rdoLeftTrim.TabIndex = 35
-        Me.rdoLeftTrim.TabStop = True
-        Me.rdoLeftTrim.Text = "Left"
-        Me.rdoLeftTrim.UseVisualStyleBackColor = True
-        '
-        'rdoRightPad
-        '
-        Me.rdoRightPad.AutoSize = True
-        Me.rdoRightPad.Location = New System.Drawing.Point(51, 3)
-        Me.rdoRightPad.Name = "rdoRightPad"
-        Me.rdoRightPad.Size = New System.Drawing.Size(50, 17)
-        Me.rdoRightPad.TabIndex = 39
-        Me.rdoRightPad.TabStop = True
-        Me.rdoRightPad.Text = "Right"
-        Me.rdoRightPad.UseVisualStyleBackColor = True
-        '
-        'rdoRightTrim
-        '
-        Me.rdoRightTrim.AutoSize = True
-        Me.rdoRightTrim.Location = New System.Drawing.Point(48, 3)
-        Me.rdoRightTrim.Name = "rdoRightTrim"
-        Me.rdoRightTrim.Size = New System.Drawing.Size(50, 17)
-        Me.rdoRightTrim.TabIndex = 36
-        Me.rdoRightTrim.TabStop = True
-        Me.rdoRightTrim.Text = "Right"
-        Me.rdoRightTrim.UseVisualStyleBackColor = True
+        Me.ucrInputPad.IsReadOnly = False
+        Me.ucrInputPad.Location = New System.Drawing.Point(135, 50)
+        Me.ucrInputPad.Name = "ucrInputPad"
+        Me.ucrInputPad.Size = New System.Drawing.Size(73, 25)
+        Me.ucrInputPad.TabIndex = 13
         '
         'nudWidth
         '
@@ -410,45 +472,9 @@ Partial Class dlgTransformText
         Me.lblWidth.TabIndex = 11
         Me.lblWidth.Text = "Width"
         '
-        'ucrInputSeparator
-        '
-        Me.ucrInputSeparator.Location = New System.Drawing.Point(69, 105)
-        Me.ucrInputSeparator.Name = "ucrInputSeparator"
-        Me.ucrInputSeparator.Size = New System.Drawing.Size(73, 25)
-        Me.ucrInputSeparator.TabIndex = 17
-        '
-        'ucrReceiverLastWord
-        '
-        Me.ucrReceiverLastWord.Location = New System.Drawing.Point(148, 76)
-        Me.ucrReceiverLastWord.Name = "ucrReceiverLastWord"
-        Me.ucrReceiverLastWord.Selector = Nothing
-        Me.ucrReceiverLastWord.Size = New System.Drawing.Size(107, 26)
-        Me.ucrReceiverLastWord.TabIndex = 27
-        '
-        'ucrReceiverFirstWord
-        '
-        Me.ucrReceiverFirstWord.Location = New System.Drawing.Point(148, 36)
-        Me.ucrReceiverFirstWord.Name = "ucrReceiverFirstWord"
-        Me.ucrReceiverFirstWord.Selector = Nothing
-        Me.ucrReceiverFirstWord.Size = New System.Drawing.Size(107, 26)
-        Me.ucrReceiverFirstWord.TabIndex = 13
-        '
-        'ucrInputTo
-        '
-        Me.ucrInputTo.Location = New System.Drawing.Point(32, 19)
-        Me.ucrInputTo.Name = "ucrInputTo"
-        Me.ucrInputTo.Size = New System.Drawing.Size(73, 25)
-        Me.ucrInputTo.TabIndex = 8
-        '
-        'ucrInputPad
-        '
-        Me.ucrInputPad.Location = New System.Drawing.Point(135, 50)
-        Me.ucrInputPad.Name = "ucrInputPad"
-        Me.ucrInputPad.Size = New System.Drawing.Size(73, 25)
-        Me.ucrInputPad.TabIndex = 13
-        '
         'ucrInputPrefixForNewColumn
         '
+        Me.ucrInputPrefixForNewColumn.IsReadOnly = False
         Me.ucrInputPrefixForNewColumn.Location = New System.Drawing.Point(107, 359)
         Me.ucrInputPrefixForNewColumn.Name = "ucrInputPrefixForNewColumn"
         Me.ucrInputPrefixForNewColumn.Size = New System.Drawing.Size(187, 25)
@@ -457,6 +483,7 @@ Partial Class dlgTransformText
         'ucrReceiverTransformText
         '
         Me.ucrReceiverTransformText.Location = New System.Drawing.Point(253, 29)
+        Me.ucrReceiverTransformText.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverTransformText.Name = "ucrReceiverTransformText"
         Me.ucrReceiverTransformText.Selector = Nothing
         Me.ucrReceiverTransformText.Size = New System.Drawing.Size(107, 26)
@@ -464,7 +491,10 @@ Partial Class dlgTransformText
         '
         'ucrSelectorForTransformText
         '
+        Me.ucrSelectorForTransformText.bShowHiddenColumns = False
+        Me.ucrSelectorForTransformText.bUseCurrentFilter = False
         Me.ucrSelectorForTransformText.Location = New System.Drawing.Point(5, 12)
+        Me.ucrSelectorForTransformText.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorForTransformText.Name = "ucrSelectorForTransformText"
         Me.ucrSelectorForTransformText.Size = New System.Drawing.Size(242, 179)
         Me.ucrSelectorForTransformText.TabIndex = 1
@@ -475,26 +505,6 @@ Partial Class dlgTransformText
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(410, 53)
         Me.ucrBase.TabIndex = 0
-        '
-        'pnlPad
-        '
-        Me.pnlPad.Controls.Add(Me.rdoBothPad)
-        Me.pnlPad.Controls.Add(Me.rdoLeftPad)
-        Me.pnlPad.Controls.Add(Me.rdoRightPad)
-        Me.pnlPad.Location = New System.Drawing.Point(11, 16)
-        Me.pnlPad.Name = "pnlPad"
-        Me.pnlPad.Size = New System.Drawing.Size(154, 24)
-        Me.pnlPad.TabIndex = 41
-        '
-        'pnlTrim
-        '
-        Me.pnlTrim.Controls.Add(Me.rdoBothTrim)
-        Me.pnlTrim.Controls.Add(Me.rdoLeftTrim)
-        Me.pnlTrim.Controls.Add(Me.rdoRightTrim)
-        Me.pnlTrim.Location = New System.Drawing.Point(11, 15)
-        Me.pnlTrim.Name = "pnlTrim"
-        Me.pnlTrim.Size = New System.Drawing.Size(154, 24)
-        Me.pnlTrim.TabIndex = 42
         '
         'dlgTransformText
         '
@@ -521,11 +531,11 @@ Partial Class dlgTransformText
         CType(Me.nudFirstWord, System.ComponentModel.ISupportInitialize).EndInit()
         Me.grpParameters.ResumeLayout(False)
         Me.grpParameters.PerformLayout()
-        CType(Me.nudWidth, System.ComponentModel.ISupportInitialize).EndInit()
-        Me.pnlPad.ResumeLayout(False)
-        Me.pnlPad.PerformLayout()
         Me.pnlTrim.ResumeLayout(False)
         Me.pnlTrim.PerformLayout()
+        Me.pnlPad.ResumeLayout(False)
+        Me.pnlPad.PerformLayout()
+        CType(Me.nudWidth, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/instat/dlgUnstack.Designer.vb
+++ b/instat/dlgUnstack.Designer.vb
@@ -22,7 +22,6 @@ Partial Class dlgUnstack
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(dlgUnstack))
         Me.lblFactorToUnstackBy = New System.Windows.Forms.Label()
         Me.lblColumnToUnstack = New System.Windows.Forms.Label()
         Me.chkDropMissingCombinations = New System.Windows.Forms.CheckBox()
@@ -38,77 +37,108 @@ Partial Class dlgUnstack
         '
         'lblFactorToUnstackBy
         '
-        resources.ApplyResources(Me.lblFactorToUnstackBy, "lblFactorToUnstackBy")
+        Me.lblFactorToUnstackBy.Location = New System.Drawing.Point(287, 32)
         Me.lblFactorToUnstackBy.Name = "lblFactorToUnstackBy"
+        Me.lblFactorToUnstackBy.Size = New System.Drawing.Size(121, 16)
+        Me.lblFactorToUnstackBy.TabIndex = 8
         Me.lblFactorToUnstackBy.Tag = "Factor_to_Unstack_By"
+        Me.lblFactorToUnstackBy.Text = "Factor to Unstack by:"
         '
         'lblColumnToUnstack
         '
-        resources.ApplyResources(Me.lblColumnToUnstack, "lblColumnToUnstack")
+        Me.lblColumnToUnstack.Location = New System.Drawing.Point(288, 80)
         Me.lblColumnToUnstack.Name = "lblColumnToUnstack"
+        Me.lblColumnToUnstack.Size = New System.Drawing.Size(119, 23)
+        Me.lblColumnToUnstack.TabIndex = 7
         Me.lblColumnToUnstack.Tag = "Column_to_Unstack"
+        Me.lblColumnToUnstack.Text = "Column to Unstack by:"
         '
         'chkDropMissingCombinations
         '
-        resources.ApplyResources(Me.chkDropMissingCombinations, "chkDropMissingCombinations")
+        Me.chkDropMissingCombinations.Location = New System.Drawing.Point(10, 201)
         Me.chkDropMissingCombinations.Name = "chkDropMissingCombinations"
+        Me.chkDropMissingCombinations.Size = New System.Drawing.Size(210, 24)
+        Me.chkDropMissingCombinations.TabIndex = 6
         Me.chkDropMissingCombinations.Tag = "Drop_Missing_Combinations"
+        Me.chkDropMissingCombinations.Text = "Drop Missing Combinations"
         Me.chkDropMissingCombinations.UseVisualStyleBackColor = True
         '
         'lblDataFrameForUnstack
         '
-        resources.ApplyResources(Me.lblDataFrameForUnstack, "lblDataFrameForUnstack")
+        Me.lblDataFrameForUnstack.Location = New System.Drawing.Point(8, 231)
         Me.lblDataFrameForUnstack.Name = "lblDataFrameForUnstack"
+        Me.lblDataFrameForUnstack.Size = New System.Drawing.Size(125, 23)
+        Me.lblDataFrameForUnstack.TabIndex = 3
         Me.lblDataFrameForUnstack.Tag = "New_Data_Frame_Name"
+        Me.lblDataFrameForUnstack.Text = "New Data Frame Name:"
         '
         'lblIDColumns
         '
-        resources.ApplyResources(Me.lblIDColumns, "lblIDColumns")
+        Me.lblIDColumns.Location = New System.Drawing.Point(288, 130)
         Me.lblIDColumns.Name = "lblIDColumns"
+        Me.lblIDColumns.Size = New System.Drawing.Size(100, 23)
+        Me.lblIDColumns.TabIndex = 1
         Me.lblIDColumns.Tag = "ID_Columns"
+        Me.lblIDColumns.Text = "ID Columns:"
         '
         'ucrNewDataName
         '
         Me.ucrNewDataName.IsReadOnly = False
-        resources.ApplyResources(Me.ucrNewDataName, "ucrNewDataName")
+        Me.ucrNewDataName.Location = New System.Drawing.Point(133, 229)
         Me.ucrNewDataName.Name = "ucrNewDataName"
+        Me.ucrNewDataName.Size = New System.Drawing.Size(137, 21)
+        Me.ucrNewDataName.TabIndex = 0
         '
         'ucrIDColumns
         '
-        resources.ApplyResources(Me.ucrIDColumns, "ucrIDColumns")
+        Me.ucrIDColumns.Location = New System.Drawing.Point(288, 150)
+        Me.ucrIDColumns.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrIDColumns.Name = "ucrIDColumns"
         Me.ucrIDColumns.Selector = Nothing
+        Me.ucrIDColumns.Size = New System.Drawing.Size(120, 100)
+        Me.ucrIDColumns.TabIndex = 2
         '
         'ucrColumnToUnstackReceiver
         '
-        resources.ApplyResources(Me.ucrColumnToUnstackReceiver, "ucrColumnToUnstackReceiver")
+        Me.ucrColumnToUnstackReceiver.Location = New System.Drawing.Point(289, 97)
+        Me.ucrColumnToUnstackReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrColumnToUnstackReceiver.Name = "ucrColumnToUnstackReceiver"
         Me.ucrColumnToUnstackReceiver.Selector = Nothing
+        Me.ucrColumnToUnstackReceiver.Size = New System.Drawing.Size(120, 20)
+        Me.ucrColumnToUnstackReceiver.TabIndex = 4
         '
         'ucrFactorToUnstackReceiver
         '
-        resources.ApplyResources(Me.ucrFactorToUnstackReceiver, "ucrFactorToUnstackReceiver")
+        Me.ucrFactorToUnstackReceiver.Location = New System.Drawing.Point(289, 49)
+        Me.ucrFactorToUnstackReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrFactorToUnstackReceiver.Name = "ucrFactorToUnstackReceiver"
         Me.ucrFactorToUnstackReceiver.Selector = Nothing
+        Me.ucrFactorToUnstackReceiver.Size = New System.Drawing.Size(120, 20)
+        Me.ucrFactorToUnstackReceiver.TabIndex = 5
         '
         'ucrSelectorForunstack
         '
         Me.ucrSelectorForunstack.bShowHiddenColumns = False
         Me.ucrSelectorForunstack.bUseCurrentFilter = False
-        resources.ApplyResources(Me.ucrSelectorForunstack, "ucrSelectorForunstack")
+        Me.ucrSelectorForunstack.Location = New System.Drawing.Point(10, 10)
+        Me.ucrSelectorForunstack.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorForunstack.Name = "ucrSelectorForunstack"
+        Me.ucrSelectorForunstack.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorForunstack.TabIndex = 9
         '
         'ucrBase
         '
-        resources.ApplyResources(Me.ucrBase, "ucrBase")
+        Me.ucrBase.Location = New System.Drawing.Point(10, 259)
         Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 10
         '
         'dlgUnstack
         '
-        resources.ApplyResources(Me, "$this")
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(421, 318)
         Me.Controls.Add(Me.ucrNewDataName)
-        Me.Controls.Add(Me.lblIDColumns)
         Me.Controls.Add(Me.ucrIDColumns)
         Me.Controls.Add(Me.lblDataFrameForUnstack)
         Me.Controls.Add(Me.ucrColumnToUnstackReceiver)
@@ -118,13 +148,13 @@ Partial Class dlgUnstack
         Me.Controls.Add(Me.lblFactorToUnstackBy)
         Me.Controls.Add(Me.ucrSelectorForunstack)
         Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.lblIDColumns)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgUnstack"
         Me.Tag = "Unstack_Columns"
         Me.ResumeLayout(False)
-        Me.PerformLayout()
 
     End Sub
     Friend WithEvents ucrBase As ucrButtons

--- a/instat/dlgUnstack.vb
+++ b/instat/dlgUnstack.vb
@@ -63,7 +63,7 @@ Public Class dlgUnstack
     End Sub
 
     Private Sub TestOKEnabled()
-        If Not ucrFactorToUnstackReceiver.IsEmpty() AndAlso Not ucrColumnToUnstackReceiver.IsEmpty() AndAlso Not ucrIDColumns.IsEmpty() Then
+        If Not ucrFactorToUnstackReceiver.IsEmpty() AndAlso Not ucrColumnToUnstackReceiver.IsEmpty() AndAlso Not ucrIDColumns.IsEmpty() AndAlso Not ucrNewDataName.IsEmpty() Then
             ucrBase.OKEnabled(True)
         Else
             ucrBase.OKEnabled(False)


### PR DESCRIPTION
- Transform Text (Corrected a spelling error)
- Factor: Combine (The dialog was in the top left hand corner)
- Split (Dialog was in top LHC)
- Rename Descriptive (Dialog was in top LHC)
- Name (Dialog was in top LHC)
- Unstacked (Dialog was in top LHC, and amended a TestOKEnabled code)