### PR TITLE
Changes on the specify origin option

### DIFF
--- a/instat/dlgMakeDate.vb
+++ b/instat/dlgMakeDate.vb
@@ -16,7 +16,6 @@
 
 Imports instat.Translations
 Public Class dlgMakeDate
-    Public clsPaste As New RFunction
     Public bFirstLoad As Boolean = True
     Private Sub ucrSeclectorMakeDate_Load(sender As Object, e As EventArgs) Handles ucrSeclectorMakeDate.Load
         If bFirstLoad Then
@@ -42,12 +41,16 @@ Public Class dlgMakeDate
         ucrInputDay.SetItems({"%d (1-31)", "%j (1-366)"})
         ucrInputComboBoxMonthTwo.SetItems({"365/366", "366"})
         ucrInputComboBoxYearTwo.SetItems({"4 digits", "2 digits"})
-        ucrInputFormat.SetItems({"%Y-%m-%d", "%Y/%m/%d", "%d%m%Y"})
+        ucrInputFormat.SetItems({"%Y-%m-%d", "%d/%m/%Y", "%d%m%Y"})
         ucrInputComboBoxTearThree.SetItems({"4 digits", "2 digits"})
-        ucrInputOrigin.SetItems({"30-12-1899 (Excel)", "01-03-1600 (Gregorian)"})
+        ucrInputOrigin.SetItems({"1899-12-30 (Excel)", "1600-03-01 (Gregorian)"})
+        ucrReceiverForDate.Selector = ucrSeclectorMakeDate
+        ucrReceiverYearTwo.Selector = ucrSeclectorMakeDate
+        ucrReceiverDayTwo.Selector = ucrSeclectorMakeDate
+        ucrReceiverYearThree.Selector = ucrSeclectorMakeDate
+        ucrReceiverMonthThree.Selector = ucrSeclectorMakeDate
+        ucrReceiverDayThree.Selector = ucrSeclectorMakeDate
 
-        ucrBase.clsRsyntax.SetFunction("as.Date")
-        ucrBase.clsRsyntax.AddParameter("x")
 
     End Sub
     Private Sub SetDefaults()
@@ -56,7 +59,7 @@ Public Class dlgMakeDate
         ucrInputNewColumnName.Reset()
         ucrSeclectorMakeDate.Reset()
         ucrInputFormat.Reset()
-        ucrInputFormat.SetName("%Y-%m-%d")
+        ucrInputFormat.SetName("%d/%m/%Y")
         ucrInputSeparator.SetName("/")
         ucrInputYear.SetName("%Y (4 digits)")
         ucrInputMonth.SetName("%m (1-12)")
@@ -64,13 +67,12 @@ Public Class dlgMakeDate
         ucrInputComboBoxTearThree.SetName("4 digits (eg 1920)")
         ucrInputComboBoxMonthTwo.SetName("365/366")
         ucrInputComboBoxYearTwo.SetName("4 digits (eg 1920)")
-        ucrInputOrigin.SetName("30-12-1899 (Excel)")
+        ucrInputOrigin.SetName("1899-12-30 (Excel)")
         grpFormatField.Visible = False
         ucrInputOrigin.Visible = False
         ucrInputNewColumnName.SetPrefix("Date")
         TestOKEnabled()
         rdoSingleColumn.Checked = True
-        ShowGroups()
     End Sub
     Private Sub TestOKEnabled()
         If ((Not ucrReceiverForDate.IsEmpty) OrElse ((Not ucrReceiverYearTwo.IsEmpty) AndAlso (Not ucrReceiverDayTwo.IsEmpty)) OrElse ((Not ucrReceiverDayThree.IsEmpty) AndAlso (Not ucrReceiverMonthThree.IsEmpty) AndAlso (Not ucrReceiverYearThree.IsEmpty))) Then
@@ -98,88 +100,18 @@ Public Class dlgMakeDate
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
     End Sub
-    Private Sub ucrReceiverForDate_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverForDate.SelectionChanged
-        DateCols()
+    Private Sub ucrReceiverForDate_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverForDate.SelectionChanged, ucrReceiverDayThree.SelectionChanged, ucrReceiverDayTwo.SelectionChanged, ucrReceiverMonthThree.SelectionChanged, ucrReceiverYearThree.SelectionChanged, ucrReceiverYearTwo.SelectionChanged
+        Formats()
         TestOKEnabled()
     End Sub
 
-    Private Sub DateCols()
-        If rdoSingleColumn.Checked Then
-            If Not ucrReceiverForDate.IsEmpty Then
-                ucrBase.clsRsyntax.AddParameter("x", clsRFunctionParameter:=ucrReceiverForDate.GetVariables())
-
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("x")
-            End If
-        ElseIf rdoYearandDayofYear.Checked Then
-
-        Else
-
-            If Not ucrReceiverMonthThree.IsEmpty AndAlso Not ucrReceiverDayThree.IsEmpty AndAlso Not ucrReceiverYearThree.IsEmpty Then
-
-                clsPaste.SetRCommand("paste")
-                clsPaste.AddParameter("sep", Chr(34) & "" & Chr(34))
-                clsPaste.AddParameter("x")
-            End If
-        End If
-    End Sub
-
-    Private Sub ucrReceiverForDate_Load(sender As Object, e As EventArgs)
-
-    End Sub
-
-    Private Sub rdoSingleColumn_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSingleColumn.CheckedChanged, rdoYearandDayofYear.CheckedChanged, rdoYearMonthDay.CheckedChanged
-        ShowGroups()
-    End Sub
-
-    Private Sub ShowGroups()
-        If rdoSingleColumn.Checked Then
-            ucrReceiverForDate.Selector = ucrSeclectorMakeDate
-            ucrReceiverForDate.SetMeAsReceiver()
-            grpSingleColumn.Visible = True
-            grpTwoColumns.Visible = False
-            grpThreeColumns.Visible = False
-        ElseIf rdoYearandDayofYear.Checked Then
-            ucrReceiverYearTwo.Selector = ucrSeclectorMakeDate
-            ucrReceiverDayTwo.Selector = ucrSeclectorMakeDate
-            ucrReceiverYearTwo.SetMeAsReceiver()
-            grpTwoColumns.Visible = True
-            grpThreeColumns.Visible = False
-            grpSingleColumn.Visible = False
-        Else
-            ucrReceiverYearThree.Selector = ucrSeclectorMakeDate
-            ucrReceiverMonthThree.Selector = ucrSeclectorMakeDate
-            ucrReceiverDayThree.Selector = ucrSeclectorMakeDate
-            ucrReceiverYearThree.SetMeAsReceiver()
-            grpThreeColumns.Visible = True
-            grpTwoColumns.Visible = False
-            grpSingleColumn.Visible = False
-        End If
-    End Sub
-    Private Sub ShowOrigin()
-        If rdoSpecifyOrigin.Checked Then
-            ucrInputOrigin.Visible = True
-        Else
-            ucrInputOrigin.Visible = False
-        End If
-    End Sub
-
-    Private Sub showFormat()
-        If chkMore.Checked Then
-            grpFormatField.Visible = True
-        Else
-            grpFormatField.Visible = False
-        End If
-    End Sub
-
-    Private Sub rdoSpecifyOrigin_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSpecifyOrigin.CheckedChanged, rdoSpecifyFormat.CheckedChanged
-        ShowOrigin()
+    Private Sub rdoSingleColumn_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSingleColumn.CheckedChanged, rdoYearandDayofYear.CheckedChanged, rdoYearMonthDay.CheckedChanged, rdoSpecifyOrigin.CheckedChanged, rdoSpecifyFormat.CheckedChanged, rdoDefaultFormat.CheckedChanged
         Formats()
+        TestOKEnabled()
     End Sub
-
 
     Private Sub chkMore_CheckedChanged(sender As Object, e As EventArgs) Handles chkMore.CheckedChanged
-        showFormat()
+        Formats()
     End Sub
 
     Private Sub ucrInputSpecifyDates_NameChanged() Handles ucrInputFormat.NameChanged
@@ -187,7 +119,7 @@ Public Class dlgMakeDate
     End Sub
 
     Private Sub ucrSeclectorMakeDate_DataFrameChanged() Handles ucrSeclectorMakeDate.DataFrameChanged
-
+        Formats()
     End Sub
 
 
@@ -196,32 +128,111 @@ Public Class dlgMakeDate
     End Sub
 
     Private Sub Formats()
-        If rdoSpecifyOrigin.Checked Then
-            ucrInputFormat.Visible = False
-            ucrBase.clsRsyntax.RemoveParameter("format")
-            If Not ucrInputOrigin.IsEmpty Then
-                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & ucrInputOrigin.GetText & Chr(34))
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("origin")
+        If rdoSingleColumn.Checked Then
 
-            End If
-        ElseIf rdoSpecifyFormat.Checked Then
-            ucrBase.clsRsyntax.RemoveParameter("origin")
-            ucrInputFormat.Visible = True
-            If Not ucrInputFormat.IsEmpty Then
-                ucrBase.clsRsyntax.AddParameter("format", Chr(34) & ucrInputFormat.GetText & Chr(34))
+            ucrReceiverForDate.SetMeAsReceiver()
+            grpSingleColumn.Visible = True
+            grpTwoColumns.Visible = False
+            grpThreeColumns.Visible = False
+            ucrBase.clsRsyntax.SetFunction("as.Date")
+            If chkMore.Checked Then
+                grpFormatField.Visible = True
             Else
-                ucrBase.clsRsyntax.RemoveParameter("format")
+                grpFormatField.Visible = False
             End If
+            If Not ucrReceiverForDate.IsEmpty Then
+                ucrBase.clsRsyntax.AddParameter("x", clsRFunctionParameter:=ucrReceiverForDate.GetVariables())
+
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("x")
+            End If
+            If rdoSpecifyOrigin.Checked Then
+                ucrReceiverForDate.SetIncludedDataTypes({"numeric"})
+                ucrInputFormat.Visible = False
+                ucrInputOrigin.Visible = True
+                ucrBase.clsRsyntax.RemoveParameter("format")
+                If Not ucrInputOrigin.IsEmpty Then
+                    ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & ucrInputOrigin.GetText & Chr(34))
+                Else
+                    ucrBase.clsRsyntax.RemoveParameter("origin")
+
+
+                End If
+            ElseIf rdoSpecifyFormat.Checked Then
+                ucrReceiverForDate.SetIncludedDataTypes({"numeric", "character", "factor", "integer"})
+
+                ucrBase.clsRsyntax.RemoveParameter("origin")
+                ucrInputFormat.Visible = True
+                ucrInputOrigin.Visible = False
+
+                If Not ucrInputFormat.IsEmpty Then
+                    ucrBase.clsRsyntax.AddParameter("format", Chr(34) & ucrInputFormat.GetText & Chr(34))
+                Else
+                    ucrBase.clsRsyntax.RemoveParameter("format")
+                End If
+            Else
+                ucrInputOrigin.Visible = False
+                ucrInputFormat.Visible = False
+                ucrReceiverForDate.SetIncludedDataTypes({"numeric", "character", "factor", "integer"})
+                ucrBase.clsRsyntax.RemoveParameter("format")
+                ucrBase.clsRsyntax.RemoveParameter("origin")
+            End If
+            ucrBase.clsRsyntax.RemoveParameter("year")
+            ucrBase.clsRsyntax.RemoveParameter("doy")
+            ucrBase.clsRsyntax.RemoveParameter("month")
+            ucrBase.clsRsyntax.RemoveParameter("day")
+            ucrBase.clsRsyntax.RemoveParameter("data_name")
+        ElseIf rdoYearandDayofYear.Checked Then
+            ucrReceiverYearTwo.SetMeAsReceiver()
+            ucrBase.clsRsyntax.AddParameter("data_name", Chr(34) & ucrSeclectorMakeDate.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem & Chr(34))
+            ucrBase.clsRsyntax.RemoveParameter("x")
+            ucrBase.clsRsyntax.RemoveParameter("format")
+            ucrBase.clsRsyntax.RemoveParameter("origin")
+            ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$make_date_yeardoy")
+            grpTwoColumns.Visible = True
+            grpThreeColumns.Visible = False
+            grpSingleColumn.Visible = False
+
+            If ucrReceiverYearTwo.IsEmpty = False Then
+                ucrBase.clsRsyntax.AddParameter("year", ucrReceiverYearTwo.GetVariableNames())
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("year")
+            End If
+            If ucrReceiverDayTwo.IsEmpty = False Then
+                ucrBase.clsRsyntax.AddParameter("doy", ucrReceiverDayTwo.GetVariableNames())
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("doy")
+            End If
+            ucrBase.clsRsyntax.RemoveParameter("month")
+            ucrBase.clsRsyntax.RemoveParameter("day")
         Else
-            ucrInputFormat.Visible = False
+            ucrReceiverYearThree.SetMeAsReceiver()
+            ucrBase.clsRsyntax.AddParameter("data_name", Chr(34) & ucrSeclectorMakeDate.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem & Chr(34))
+            ucrBase.clsRsyntax.RemoveParameter("doy")
+            ucrBase.clsRsyntax.RemoveParameter("year")
+            ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$make_date_yearmonthday")
+            If Not ucrReceiverYearThree.IsEmpty Then
+                ucrBase.clsRsyntax.AddParameter("year", ucrReceiverYearThree.GetVariableNames())
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("year")
+            End If
+            If ucrReceiverMonthThree.IsEmpty = False Then
+                ucrBase.clsRsyntax.AddParameter("month", ucrReceiverMonthThree.GetVariableNames())
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("month")
+            End If
+            If ucrReceiverDayThree.IsEmpty = False Then
+                ucrBase.clsRsyntax.AddParameter("day", ucrReceiverDayThree.GetVariableNames())
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("day")
+            End If
+            grpThreeColumns.Visible = True
+            grpTwoColumns.Visible = False
+            grpSingleColumn.Visible = False
+            ucrBase.clsRsyntax.RemoveParameter("x")
             ucrBase.clsRsyntax.RemoveParameter("format")
             ucrBase.clsRsyntax.RemoveParameter("origin")
         End If
     End Sub
+
 End Class
-
-
-
-
-

--- a/instat/dlgMakeDate.vb
+++ b/instat/dlgMakeDate.vb
@@ -81,10 +81,10 @@ Public Class dlgMakeDate
     End Sub
     Private Sub DateFormat()
         Select Case ucrInputOrigin.GetText
-            Case "30-12-1899 (Excel)"
-                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1899-12-30(Excel)" & Chr(34))
+            Case "30-12-1899"
+                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1899-12-30)" & Chr(34))
             Case Else
-                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1600-01-03 (Gregorian)" & Chr(34))
+                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1600-01-03)" & Chr(34))
         End Select
     End Sub
 

--- a/instat/dlgMakeDate.vb
+++ b/instat/dlgMakeDate.vb
@@ -16,6 +16,7 @@
 
 Imports instat.Translations
 Public Class dlgMakeDate
+    Public clsPaste As New RFunction
     Public bFirstLoad As Boolean = True
     Private Sub ucrSeclectorMakeDate_Load(sender As Object, e As EventArgs) Handles ucrSeclectorMakeDate.Load
         If bFirstLoad Then
@@ -41,16 +42,12 @@ Public Class dlgMakeDate
         ucrInputDay.SetItems({"%d (1-31)", "%j (1-366)"})
         ucrInputComboBoxMonthTwo.SetItems({"365/366", "366"})
         ucrInputComboBoxYearTwo.SetItems({"4 digits", "2 digits"})
-        ucrInputFormat.SetItems({"%Y-%m-%d", "%d/%m/%Y", "%d%m%Y"})
+        ucrInputFormat.SetItems({"%Y-%m-%d", "%Y/%m/%d", "%d%m%Y"})
         ucrInputComboBoxTearThree.SetItems({"4 digits", "2 digits"})
-        ucrInputOrigin.SetItems({"1899-12-30 (Excel)", "1600-03-01 (Gregorian)"})
-        ucrReceiverForDate.Selector = ucrSeclectorMakeDate
-        ucrReceiverYearTwo.Selector = ucrSeclectorMakeDate
-        ucrReceiverDayTwo.Selector = ucrSeclectorMakeDate
-        ucrReceiverYearThree.Selector = ucrSeclectorMakeDate
-        ucrReceiverMonthThree.Selector = ucrSeclectorMakeDate
-        ucrReceiverDayThree.Selector = ucrSeclectorMakeDate
+        ucrInputOrigin.SetItems({"30-12-1899 (Excel)", "01-03-1600 (Gregorian)"})
 
+        ucrBase.clsRsyntax.SetFunction("as.Date")
+        ucrBase.clsRsyntax.AddParameter("x")
 
     End Sub
     Private Sub SetDefaults()
@@ -59,7 +56,7 @@ Public Class dlgMakeDate
         ucrInputNewColumnName.Reset()
         ucrSeclectorMakeDate.Reset()
         ucrInputFormat.Reset()
-        ucrInputFormat.SetName("%d/%m/%Y")
+        ucrInputFormat.SetName("%Y-%m-%d")
         ucrInputSeparator.SetName("/")
         ucrInputYear.SetName("%Y (4 digits)")
         ucrInputMonth.SetName("%m (1-12)")
@@ -67,12 +64,13 @@ Public Class dlgMakeDate
         ucrInputComboBoxTearThree.SetName("4 digits (eg 1920)")
         ucrInputComboBoxMonthTwo.SetName("365/366")
         ucrInputComboBoxYearTwo.SetName("4 digits (eg 1920)")
-        ucrInputOrigin.SetName("1899-12-30 (Excel)")
+        ucrInputOrigin.SetName("30-12-1899 (Excel)")
         grpFormatField.Visible = False
         ucrInputOrigin.Visible = False
         ucrInputNewColumnName.SetPrefix("Date")
         TestOKEnabled()
         rdoSingleColumn.Checked = True
+        ShowGroups()
     End Sub
     Private Sub TestOKEnabled()
         If ((Not ucrReceiverForDate.IsEmpty) OrElse ((Not ucrReceiverYearTwo.IsEmpty) AndAlso (Not ucrReceiverDayTwo.IsEmpty)) OrElse ((Not ucrReceiverDayThree.IsEmpty) AndAlso (Not ucrReceiverMonthThree.IsEmpty) AndAlso (Not ucrReceiverYearThree.IsEmpty))) Then
@@ -80,6 +78,14 @@ Public Class dlgMakeDate
         Else
             ucrBase.OKEnabled(False)
         End If
+    End Sub
+    Private Sub DateFormat()
+        Select Case ucrInputOrigin.GetText
+            Case "30-12-1899 (Excel)"
+                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1899-12-30(Excel)" & Chr(34))
+            Case Else
+                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1600-01-03 (Gregorian)" & Chr(34))
+        End Select
     End Sub
 
     Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
@@ -100,18 +106,88 @@ Public Class dlgMakeDate
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
     End Sub
-    Private Sub ucrReceiverForDate_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverForDate.SelectionChanged, ucrReceiverDayThree.SelectionChanged, ucrReceiverDayTwo.SelectionChanged, ucrReceiverMonthThree.SelectionChanged, ucrReceiverYearThree.SelectionChanged, ucrReceiverYearTwo.SelectionChanged
-        Formats()
+    Private Sub ucrReceiverForDate_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverForDate.SelectionChanged
+        DateCols()
         TestOKEnabled()
     End Sub
 
-    Private Sub rdoSingleColumn_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSingleColumn.CheckedChanged, rdoYearandDayofYear.CheckedChanged, rdoYearMonthDay.CheckedChanged, rdoSpecifyOrigin.CheckedChanged, rdoSpecifyFormat.CheckedChanged, rdoDefaultFormat.CheckedChanged
-        Formats()
-        TestOKEnabled()
+    Private Sub DateCols()
+        If rdoSingleColumn.Checked Then
+            If Not ucrReceiverForDate.IsEmpty Then
+                ucrBase.clsRsyntax.AddParameter("x", clsRFunctionParameter:=ucrReceiverForDate.GetVariables())
+
+            Else
+                ucrBase.clsRsyntax.RemoveParameter("x")
+            End If
+        ElseIf rdoYearandDayofYear.Checked Then
+
+        Else
+
+            If Not ucrReceiverMonthThree.IsEmpty AndAlso Not ucrReceiverDayThree.IsEmpty AndAlso Not ucrReceiverYearThree.IsEmpty Then
+
+                clsPaste.SetRCommand("paste")
+                clsPaste.AddParameter("sep", Chr(34) & "" & Chr(34))
+                clsPaste.AddParameter("x")
+            End If
+        End If
     End Sub
+
+    Private Sub ucrReceiverForDate_Load(sender As Object, e As EventArgs)
+
+    End Sub
+
+    Private Sub rdoSingleColumn_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSingleColumn.CheckedChanged, rdoYearandDayofYear.CheckedChanged, rdoYearMonthDay.CheckedChanged
+        ShowGroups()
+    End Sub
+
+    Private Sub ShowGroups()
+        If rdoSingleColumn.Checked Then
+            ucrReceiverForDate.Selector = ucrSeclectorMakeDate
+            ucrReceiverForDate.SetMeAsReceiver()
+            grpSingleColumn.Visible = True
+            grpTwoColumns.Visible = False
+            grpThreeColumns.Visible = False
+        ElseIf rdoYearandDayofYear.Checked Then
+            ucrReceiverYearTwo.Selector = ucrSeclectorMakeDate
+            ucrReceiverDayTwo.Selector = ucrSeclectorMakeDate
+            ucrReceiverYearTwo.SetMeAsReceiver()
+            grpTwoColumns.Visible = True
+            grpThreeColumns.Visible = False
+            grpSingleColumn.Visible = False
+        Else
+            ucrReceiverYearThree.Selector = ucrSeclectorMakeDate
+            ucrReceiverMonthThree.Selector = ucrSeclectorMakeDate
+            ucrReceiverDayThree.Selector = ucrSeclectorMakeDate
+            ucrReceiverYearThree.SetMeAsReceiver()
+            grpThreeColumns.Visible = True
+            grpTwoColumns.Visible = False
+            grpSingleColumn.Visible = False
+        End If
+    End Sub
+    Private Sub ShowOrigin()
+        If rdoSpecifyOrigin.Checked Then
+            ucrInputOrigin.Visible = True
+        Else
+            ucrInputOrigin.Visible = False
+        End If
+    End Sub
+
+    Private Sub showFormat()
+        If chkMore.Checked Then
+            grpFormatField.Visible = True
+        Else
+            grpFormatField.Visible = False
+        End If
+    End Sub
+
+    Private Sub rdoSpecifyOrigin_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSpecifyOrigin.CheckedChanged, rdoSpecifyFormat.CheckedChanged
+        ShowOrigin()
+        Formats()
+    End Sub
+
 
     Private Sub chkMore_CheckedChanged(sender As Object, e As EventArgs) Handles chkMore.CheckedChanged
-        Formats()
+        showFormat()
     End Sub
 
     Private Sub ucrInputSpecifyDates_NameChanged() Handles ucrInputFormat.NameChanged
@@ -119,120 +195,42 @@ Public Class dlgMakeDate
     End Sub
 
     Private Sub ucrSeclectorMakeDate_DataFrameChanged() Handles ucrSeclectorMakeDate.DataFrameChanged
-        Formats()
+
     End Sub
 
 
     Private Sub ucrInputOrigin_NameChanged() Handles ucrInputOrigin.NameChanged
         Formats()
+        If Not ucrInputOrigin.IsEmpty Then
+            DateFormat()
+        Else
+            ucrBase.clsRsyntax.RemoveParameter("origin")
+        End If
+
     End Sub
 
     Private Sub Formats()
-        If rdoSingleColumn.Checked Then
-
-            ucrReceiverForDate.SetMeAsReceiver()
-            grpSingleColumn.Visible = True
-            grpTwoColumns.Visible = False
-            grpThreeColumns.Visible = False
-            ucrBase.clsRsyntax.SetFunction("as.Date")
-            If chkMore.Checked Then
-                grpFormatField.Visible = True
-            Else
-                grpFormatField.Visible = False
-            End If
-            If Not ucrReceiverForDate.IsEmpty Then
-                ucrBase.clsRsyntax.AddParameter("x", clsRFunctionParameter:=ucrReceiverForDate.GetVariables())
-
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("x")
-            End If
-            If rdoSpecifyOrigin.Checked Then
-                ucrReceiverForDate.SetIncludedDataTypes({"numeric"})
-                ucrInputFormat.Visible = False
-                ucrInputOrigin.Visible = True
-                ucrBase.clsRsyntax.RemoveParameter("format")
-                If Not ucrInputOrigin.IsEmpty Then
-                    ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & ucrInputOrigin.GetText & Chr(34))
-                Else
-                    ucrBase.clsRsyntax.RemoveParameter("origin")
-
-
-                End If
-            ElseIf rdoSpecifyFormat.Checked Then
-                ucrReceiverForDate.SetIncludedDataTypes({"numeric", "character", "factor", "integer"})
-
-                ucrBase.clsRsyntax.RemoveParameter("origin")
-                ucrInputFormat.Visible = True
-                ucrInputOrigin.Visible = False
-
-                If Not ucrInputFormat.IsEmpty Then
-                    ucrBase.clsRsyntax.AddParameter("format", Chr(34) & ucrInputFormat.GetText & Chr(34))
-                Else
-                    ucrBase.clsRsyntax.RemoveParameter("format")
-                End If
-            Else
-                ucrInputOrigin.Visible = False
-                ucrInputFormat.Visible = False
-                ucrReceiverForDate.SetIncludedDataTypes({"numeric", "character", "factor", "integer"})
-                ucrBase.clsRsyntax.RemoveParameter("format")
-                ucrBase.clsRsyntax.RemoveParameter("origin")
-            End If
-            ucrBase.clsRsyntax.RemoveParameter("year")
-            ucrBase.clsRsyntax.RemoveParameter("doy")
-            ucrBase.clsRsyntax.RemoveParameter("month")
-            ucrBase.clsRsyntax.RemoveParameter("day")
-            ucrBase.clsRsyntax.RemoveParameter("data_name")
-        ElseIf rdoYearandDayofYear.Checked Then
-            ucrReceiverYearTwo.SetMeAsReceiver()
-            ucrBase.clsRsyntax.AddParameter("data_name", Chr(34) & ucrSeclectorMakeDate.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem & Chr(34))
-            ucrBase.clsRsyntax.RemoveParameter("x")
+        If rdoSpecifyOrigin.Checked Then
+            ucrInputFormat.Visible = False
             ucrBase.clsRsyntax.RemoveParameter("format")
-            ucrBase.clsRsyntax.RemoveParameter("origin")
-            ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$make_date_yeardoy")
-            grpTwoColumns.Visible = True
-            grpThreeColumns.Visible = False
-            grpSingleColumn.Visible = False
 
-            If ucrReceiverYearTwo.IsEmpty = False Then
-                ucrBase.clsRsyntax.AddParameter("year", ucrReceiverYearTwo.GetVariableNames())
+        ElseIf rdoSpecifyFormat.Checked Then
+            ucrBase.clsRsyntax.RemoveParameter("origin")
+            ucrInputFormat.Visible = True
+            If Not ucrInputFormat.IsEmpty Then
+                ucrBase.clsRsyntax.AddParameter("format", Chr(34) & ucrInputFormat.GetText & Chr(34))
             Else
-                ucrBase.clsRsyntax.RemoveParameter("year")
+                ucrBase.clsRsyntax.RemoveParameter("format")
             End If
-            If ucrReceiverDayTwo.IsEmpty = False Then
-                ucrBase.clsRsyntax.AddParameter("doy", ucrReceiverDayTwo.GetVariableNames())
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("doy")
-            End If
-            ucrBase.clsRsyntax.RemoveParameter("month")
-            ucrBase.clsRsyntax.RemoveParameter("day")
         Else
-            ucrReceiverYearThree.SetMeAsReceiver()
-            ucrBase.clsRsyntax.AddParameter("data_name", Chr(34) & ucrSeclectorMakeDate.ucrAvailableDataFrames.cboAvailableDataFrames.SelectedItem & Chr(34))
-            ucrBase.clsRsyntax.RemoveParameter("doy")
-            ucrBase.clsRsyntax.RemoveParameter("year")
-            ucrBase.clsRsyntax.SetFunction(frmMain.clsRLink.strInstatDataObject & "$make_date_yearmonthday")
-            If Not ucrReceiverYearThree.IsEmpty Then
-                ucrBase.clsRsyntax.AddParameter("year", ucrReceiverYearThree.GetVariableNames())
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("year")
-            End If
-            If ucrReceiverMonthThree.IsEmpty = False Then
-                ucrBase.clsRsyntax.AddParameter("month", ucrReceiverMonthThree.GetVariableNames())
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("month")
-            End If
-            If ucrReceiverDayThree.IsEmpty = False Then
-                ucrBase.clsRsyntax.AddParameter("day", ucrReceiverDayThree.GetVariableNames())
-            Else
-                ucrBase.clsRsyntax.RemoveParameter("day")
-            End If
-            grpThreeColumns.Visible = True
-            grpTwoColumns.Visible = False
-            grpSingleColumn.Visible = False
-            ucrBase.clsRsyntax.RemoveParameter("x")
+            ucrInputFormat.Visible = False
             ucrBase.clsRsyntax.RemoveParameter("format")
             ucrBase.clsRsyntax.RemoveParameter("origin")
         End If
     End Sub
-
 End Class
+
+
+
+
+

--- a/instat/dlgMakeDate.vb
+++ b/instat/dlgMakeDate.vb
@@ -18,7 +18,7 @@ Imports instat.Translations
 Public Class dlgMakeDate
     Public clsPaste As New RFunction
     Public bFirstLoad As Boolean = True
-    Private Sub ucrSeclectorMakeDate_Load(sender As Object, e As EventArgs) Handles ucrSeclectorMakeDate.Load
+    Private Sub dlgMakeDate_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
             SetDefaults()
@@ -81,14 +81,18 @@ Public Class dlgMakeDate
     End Sub
     Private Sub DateFormat()
         Select Case ucrInputOrigin.GetText
-            Case "30-12-1899"
-                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1899-12-30)" & Chr(34))
+            Case "30-12-1899 (Excel)"
+                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1899-12-30" & Chr(34))
             Case Else
-                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1600-01-03)" & Chr(34))
+                ucrBase.clsRsyntax.AddParameter("origin", Chr(34) & "1600-01-03" & Chr(34))
         End Select
     End Sub
 
     Private Sub ucrBase_ClickOk(sender As Object, e As EventArgs) Handles ucrBase.ClickOk
+        setHistory()
+    End Sub
+
+    Private Sub setHistory()
         If Not ucrInputFormat.cboInput.Items.Contains(ucrInputFormat.GetText) Then
             ucrInputFormat.cboInput.Items.Insert(0, ucrInputFormat.GetText)
         Else
@@ -130,10 +134,6 @@ Public Class dlgMakeDate
                 clsPaste.AddParameter("x")
             End If
         End If
-    End Sub
-
-    Private Sub ucrReceiverForDate_Load(sender As Object, e As EventArgs)
-
     End Sub
 
     Private Sub rdoSingleColumn_CheckedChanged(sender As Object, e As EventArgs) Handles rdoSingleColumn.CheckedChanged, rdoYearandDayofYear.CheckedChanged, rdoYearMonthDay.CheckedChanged
@@ -194,11 +194,6 @@ Public Class dlgMakeDate
         Formats()
     End Sub
 
-    Private Sub ucrSeclectorMakeDate_DataFrameChanged() Handles ucrSeclectorMakeDate.DataFrameChanged
-
-    End Sub
-
-
     Private Sub ucrInputOrigin_NameChanged() Handles ucrInputOrigin.NameChanged
         Formats()
         If Not ucrInputOrigin.IsEmpty Then
@@ -211,10 +206,12 @@ Public Class dlgMakeDate
 
     Private Sub Formats()
         If rdoSpecifyOrigin.Checked Then
+            ucrReceiverForDate.SetIncludedDataTypes({"numeric"})
             ucrInputFormat.Visible = False
             ucrBase.clsRsyntax.RemoveParameter("format")
 
         ElseIf rdoSpecifyFormat.Checked Then
+            ucrReceiverForDate.SetIncludedDataTypes({"numeric", "character", "factor", "integer"})
             ucrBase.clsRsyntax.RemoveParameter("origin")
             ucrInputFormat.Visible = True
             If Not ucrInputFormat.IsEmpty Then
@@ -224,6 +221,7 @@ Public Class dlgMakeDate
             End If
         Else
             ucrInputFormat.Visible = False
+            ucrReceiverForDate.SetIncludedDataTypes({"numeric", "character", "factor", "integer"})
             ucrBase.clsRsyntax.RemoveParameter("format")
             ucrBase.clsRsyntax.RemoveParameter("origin")
         End If

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1171,8 +1171,4 @@ Public Class frmMain
     Private Sub mnuOrganiseColumnMakeDate_Click(sender As Object, e As EventArgs) Handles mnuOrganiseColumnMakeDate.Click
         dlgMakeDate.ShowDialog()
     End Sub
-
-    Private Sub mnuOrganiseColumnMakeDate_Click_1(sender As Object, e As EventArgs) Handles mnuOrganiseColumnMakeDate.Click
-        dlgMakeDate.ShowDialog()
-    End Sub
 End Class


### PR DESCRIPTION
I have changed the format of origin from "30-12-1899" to "1899-12-30" for both excel and Gregorian... after noticing an anomaly in the output given.
i.e

as.Date(42034,origin="30-12-1899 (Excel)")
[1] "0146-01-18"
> as.Date(42034,origin="1899-12-30(Excel)")
[1] "2015-01-30"

 
And too put a constrain on the Single column (when specify origin is checked) to only accept numeric variables to avoid error message in case a different datatype is provided for conversion.