### PR TITLE
removed validation message to auto change an invalid R variable

### DIFF
--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -53,7 +53,7 @@ Public Class dlgImportDataset
         bCanImport = True
         bComponentsInitialised = True
         bStartOpenDialog = True
-        ucrInputName.bSuggestEditOnLeave = True
+        ucrInputName.bAutoChangeOnLeave = True
         strFilePathToUseOnLoad = ""
     End Sub
 

--- a/instat/dlgOpenSST.vb
+++ b/instat/dlgOpenSST.vb
@@ -39,7 +39,7 @@ Public Class dlgOpenSST
         bCanImport = True
         bComponentsInitialised = True
         bStartOpenDialog = True
-        ucrInputName.bSuggestEditOnLeave = True
+        ucrInputName.bAutoChangeOnLeave = True
     End Sub
 
     Private Sub dlgImportDataset_Load(sender As Object, e As EventArgs) Handles MyBase.Load

--- a/instat/ucrInput.vb
+++ b/instat/ucrInput.vb
@@ -28,7 +28,7 @@ Public Class ucrInput
     Protected strDefaultPrefix As String = ""
     Protected WithEvents ucrDataFrameSelector As ucrDataFrame
     Protected bIsReadOnly As Boolean = False
-    Public bSuggestEditOnLeave As Boolean = False
+    Public bAutoChangeOnLeave As Boolean = True
     Private bLastSilent As Boolean = False
 
     Public Overridable Sub SetName(strName As String, Optional bSilent As Boolean = False)

--- a/instat/ucrInputComboBox.vb
+++ b/instat/ucrInputComboBox.vb
@@ -22,15 +22,16 @@ Public Class ucrInputComboBox
         Dim strCurrent As String
 
         strCurrent = cboInput.Text
-        If bSuggestEditOnLeave Then
+        If bAutoChangeOnLeave Then
             If Not IsValid(strCurrent) Then
                 'TODO This message should contain the same message from ValidateText()
-                Select Case MsgBox(Chr(34) & strCurrent & Chr(34) & " is an invalid name." & vbNewLine & "Would you like it to be automatically corrected?", vbYesNo, "Invalid Name")
-                    Case MsgBoxResult.Yes
-                        SetName(frmMain.clsRLink.MakeValidText(strCurrent))
-                    Case Else
-                        e.Cancel = True
-                End Select
+                'Select Case MsgBox(Chr(34) & strCurrent & Chr(34) & " is an invalid name." & vbNewLine & "Would you like it to be automatically corrected?", vbYesNo, "Invalid Name")
+                '    Case MsgBoxResult.Yes
+                '        SetName(frmMain.clsRLink.MakeValidText(strCurrent))
+                '    Case Else
+                '        e.Cancel = True
+                'End Select
+                SetName(frmMain.clsRLink.MakeValidText(strCurrent))
             End If
         Else
             e.Cancel = Not ValidateText(strCurrent)

--- a/instat/ucrInputTextBox.vb
+++ b/instat/ucrInputTextBox.vb
@@ -37,15 +37,18 @@ Public Class ucrInputTextBox
         Dim strCurrent As String
 
         strCurrent = txtInput.Text
-        If bSuggestEditOnLeave Then
+        If bAutoChangeOnLeave Then
             If Not IsValid(strCurrent) Then
                 'TODO This message should contain the same message from ValidateText()
-                Select Case MsgBox(Chr(34) & strCurrent & Chr(34) & " is an invalid name." & vbNewLine & "Would you like it to be automatically corrected?", vbYesNo, "Invalid Name")
-                    Case MsgBoxResult.Yes
-                        SetName(frmMain.clsRLink.MakeValidText(strCurrent))
-                    Case Else
-                        e.Cancel = True
-                End Select
+                'Temp disabled so that change is done automatically
+                'TODO Think about more subtle ways to do this without being annoying to the user
+                'Select Case MsgBox(Chr(34) & strCurrent & Chr(34) & " is an invalid name." & vbNewLine & "Would you like it to be automatically corrected?", vbYesNo, "Invalid Name")
+                '    Case MsgBoxResult.Yes
+                '        SetName(frmMain.clsRLink.MakeValidText(strCurrent))
+                '    Case Else
+                '        e.Cancel = True
+                'End Select
+                SetName(frmMain.clsRLink.MakeValidText(strCurrent))
             End If
         Else
             e.Cancel = Not ValidateText(strCurrent)


### PR DESCRIPTION
auto change is now done without a message - only used in Import and SST dialog so far