### PR TITLE
Disabling Make date check boxes,..

### DIFF
--- a/instat/dlgMakeDate.vb
+++ b/instat/dlgMakeDate.vb
@@ -64,7 +64,6 @@ Public Class dlgMakeDate
         ucrInputDay.SetName("%d (1-31)")
         ucrInputComboBoxMonthTwo.SetName("365/366")
         ucrInputOrigin.SetName("30-12-1899 (Excel)")
-        grpFormatField.Visible = False
         ucrInputOrigin.Visible = False
         ucrInputNewColumnName.SetPrefix("Date")
         TestOKEnabled()
@@ -73,10 +72,24 @@ Public Class dlgMakeDate
         rdoDefaultFormat.Checked = True
         chkTwoDigitYearThree.Checked = False
         chkTwoDigitYearTwo.Checked = False
-        nudCutOffThree.Visible = False
-        nudCutOffTwo.Visible = False
+
         lblCutOffThree.Visible = False
         lblCutOffTwo.Visible = False
+        'Disabling the check boxes, Input,... which are yet to be Implemented.
+        'To be return to how it was prev...
+        chkTwoDigitYearThree.Enabled = False
+        chkTwoDigitYearTwo.Enabled = False
+        nudCutOffThree.Visible = True
+        nudCutOffTwo.Visible = True
+        nudCutOffThree.Enabled = False
+        nudCutOffTwo.Enabled = False
+        chkMore.Enabled = False
+        lblCutOffTwo.Visible = True
+        lblCutOffThree.Visible = True
+        lblCutOffThree.Enabled = False
+        lblCutOffTwo.Enabled = False
+        ucrInputComboBoxMonthTwo.Enabled = False
+
     End Sub
 
     Private Sub TestOKEnabled()
@@ -155,26 +168,29 @@ Public Class dlgMakeDate
         Else
             ucrBase.clsRsyntax.RemoveParameter("origin")
         End If
+        'to be removed later
+        grpFormatField.Visible = True
+        grpFormatField.Enabled = False
         TestOKEnabled()
     End Sub
 
     Private Sub chkMore_CheckedChanged(sender As Object, e As EventArgs) Handles chkMore.CheckedChanged, chkTwoDigitYearThree.CheckedChanged, chkTwoDigitYearTwo.CheckedChanged
         Formats()
-        If chkTwoDigitYearTwo.Checked Then
-            lblCutOffTwo.Visible = True
-            nudCutOffTwo.Visible = True
-        Else
-            lblCutOffTwo.Visible = False
-            nudCutOffTwo.Visible = False
-        End If
-        If chkTwoDigitYearThree.Checked Then
-            lblCutOffThree.Visible = True
-            nudCutOffThree.Visible = True
-        Else
-            lblCutOffThree.Visible = False
-            nudCutOffThree.Visible = False
+        'If chkTwoDigitYearTwo.Checked Then
+        'lblCutOffTwo.Visible = True
+        'nudCutOffTwo.Visible = True
+        'Else
+        'lblCutOffTwo.Visible = False
+        'nudCutOffTwo.Visible = False
+        'End If
+        'If chkTwoDigitYearThree.Checked Then
+        'lblCutOffThree.Visible = True
+        'nudCutOffThree.Visible = True
+        'Else
+        'lblCutOffThree.Visible = False
+        'nudCutOffThree.Visible = False
 
-        End If
+        'End If
     End Sub
 
     Private Sub ucrInputSpecifyDates_NameChanged() Handles ucrInputFormat.NameChanged


### PR DESCRIPTION
Disabled them because they are still awaiting to be implementation. This is to make sure that the dialogue looks good - most of them were invisible thus leaving large empty spaces on the dialog. 

*To be returned to how it was after beta release (Implemented as required).