### PR TITLE
Sdglayeroptions + ucrGeomListWithAes: solving LayerOptions bugs

### DIFF
--- a/instat/UcrGeomListWithAes.designer.vb
+++ b/instat/UcrGeomListWithAes.designer.vb
@@ -19,7 +19,7 @@ Partial Class UcrGeomListWithParameters
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Me.UcrSelector = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrGeomWithAesSelector = New instat.ucrSelectorByDataFrameAddRemove()
         Me.lblAesList = New System.Windows.Forms.Label()
         Me.ucrReceiverParam1 = New instat.ucrReceiverSingle()
         Me.ucrReceiverParam2 = New instat.ucrReceiverSingle()
@@ -47,15 +47,15 @@ Partial Class UcrGeomListWithParameters
         Me.grpAesList.SuspendLayout()
         Me.SuspendLayout()
         '
-        'UcrSelector
+        'ucrGeomWithAesSelector
         '
-        Me.UcrSelector.bShowHiddenColumns = False
-        Me.UcrSelector.bUseCurrentFilter = True
-        Me.UcrSelector.Location = New System.Drawing.Point(3, 56)
-        Me.UcrSelector.Margin = New System.Windows.Forms.Padding(0)
-        Me.UcrSelector.Name = "UcrSelector"
-        Me.UcrSelector.Size = New System.Drawing.Size(232, 192)
-        Me.UcrSelector.TabIndex = 5
+        Me.ucrGeomWithAesSelector.bShowHiddenColumns = False
+        Me.ucrGeomWithAesSelector.bUseCurrentFilter = True
+        Me.ucrGeomWithAesSelector.Location = New System.Drawing.Point(3, 56)
+        Me.ucrGeomWithAesSelector.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrGeomWithAesSelector.Name = "ucrGeomWithAesSelector"
+        Me.ucrGeomWithAesSelector.Size = New System.Drawing.Size(232, 192)
+        Me.ucrGeomWithAesSelector.TabIndex = 5
         '
         'lblAesList
         '
@@ -301,10 +301,10 @@ Partial Class UcrGeomListWithParameters
         Me.Controls.Add(Me.chkApplyOnAllLayers)
         Me.Controls.Add(Me.grpAesList)
         Me.Controls.Add(Me.lblAesList)
-        Me.Controls.Add(Me.UcrSelector)
+        Me.Controls.Add(Me.ucrGeomWithAesSelector)
         Me.Name = "UcrGeomListWithParameters"
         Me.Size = New System.Drawing.Size(467, 343)
-        Me.Controls.SetChildIndex(Me.UcrSelector, 0)
+        Me.Controls.SetChildIndex(Me.ucrGeomWithAesSelector, 0)
         Me.Controls.SetChildIndex(Me.lblAesList, 0)
         Me.Controls.SetChildIndex(Me.grpAesList, 0)
         Me.Controls.SetChildIndex(Me.chkApplyOnAllLayers, 0)
@@ -315,7 +315,7 @@ Partial Class UcrGeomListWithParameters
         Me.PerformLayout()
 
     End Sub
-    Friend WithEvents UcrSelector As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrGeomWithAesSelector As ucrSelectorByDataFrameAddRemove
     Friend WithEvents lblAesList As Label
     Friend WithEvents ucrReceiverParam1 As ucrReceiverSingle
     Friend WithEvents ucrReceiverParam2 As ucrReceiverSingle

--- a/instat/UcrGeomListWithAes.designer.vb
+++ b/instat/UcrGeomListWithAes.designer.vb
@@ -137,7 +137,7 @@ Partial Class UcrGeomListWithParameters
         Me.grpAesList.Size = New System.Drawing.Size(219, 321)
         Me.grpAesList.TabIndex = 9
         Me.grpAesList.TabStop = False
-        Me.grpAesList.Text = "Geom Aesthetics"
+        Me.grpAesList.Text = "Geom Aesthetics:"
         '
         'lblGgParam6
         '

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -73,7 +73,7 @@ Public Class UcrGeomListWithParameters
 
     Private Sub InitialiseSelectedDataFrame()
         'When setting up the ucrGeomListWithAes, we want the selected dataframe to be the one used in the clsGeomFunction that has been given through. This is also needed for the method in LocalAndGlobalDataFramesAreDifferent() to work when editing a layer.
-        Dim strDataFrameName As String = strGlobalDataFrame
+        Dim strDataFrameName As String = String.Copy(strGlobalDataFrame)
         Dim iIndexOfData_nameParameter As Integer
         If clsGeomFunction.GetParameter("data") IsNot Nothing AndAlso clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name") <> -1 Then
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
@@ -83,7 +83,6 @@ Public Class UcrGeomListWithParameters
         Else
             UcrSelector.SetDataframe(strDataFrameName, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         End If
-
     End Sub
     Public Overrides Sub Setup(clsTempGgPlot As RFunction, clsTempGeomFunc As RFunction, clsTempGlobalAesFunc As RFunction, Optional bFixAes As Boolean = False, Optional bFixGeom As Boolean = False, Optional strDataframe As String = "", Optional bApplyAesGlobally As Boolean = True, Optional bIgnoreGlobalAes As Boolean = False, Optional iNumVariablesForGeoms As Integer = -1, Optional clsTempLocalAes As RFunction = Nothing)
         'See ucrAdditionalLayers and Specific Plots dlg to see how the SetUp Parameters are chosen within the sdgLayerOptions.SetupLayer call.
@@ -106,11 +105,9 @@ Public Class UcrGeomListWithParameters
         chkApplyOnAllLayers.Checked = bApplyAesGlobally
         chkIgnoreGlobalAes.Checked = bIgnoreGlobalAes 'Note: raises the event check changed if the value has indeed changed.
 
-        UcrSelector.Reset()
+        'UcrSelector.Reset() 'Warning: Not sure this is necessary anymore... Testing will confirm.
         InitialiseSelectedDataFrame()
         'UcrSelector.SetDataframe(strGlobalDataFrame, (Not bApplyAesGlobally) OrElse strGlobalDataFrame = "")
-
-
 
 
         bCurrentFixAes = bFixAes 'Warning/Question/Task: this is not flexible enough. Some of the aesthetics are set in the options. They cannot be editted on the main, however when coming back to options these are fixed and so cannot be editted anywhere anymore. Would need to be able to choose which aesthetics among a Layer should be fixed maybe.
@@ -136,8 +133,8 @@ Public Class UcrGeomListWithParameters
         For i = 0 To clsCurrGeom.clsAesParameters.Count - 1
             'Clear the potentially up to date content of the Aesthetics receivers. If the content of lstAesParameterUcr(i) is still relevant, then one of the parameters's name in clsGgplotAesFunction will match lstCurrArguments(i) and the value recovered accordingly.
             'Warning/Question: when geom is changed, local aes of previous geom are not kept. Is that fine ? Could change the method for layer to remember the previous selection for common aes between the two geoms.
-            lstAesParameterUcr(i).Clear()
             lstAesParameterUcr(i).Enabled = True
+            lstAesParameterUcr(i).Clear()
             'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers.
             If Not chkIgnoreGlobalAes.Checked Then
                 For Each clsParam In clsGgplotAesFunction.clsParameters

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -107,7 +107,7 @@ Public Class UcrGeomListWithParameters
 
         'UcrSelector.Reset() 'Warning: Not sure this is necessary anymore... Testing will confirm.
         InitialiseSelectedDataFrame()
-        'UcrSelector.SetDataframe(strGlobalDataFrame, (Not bApplyAesGlobally) OrElse strGlobalDataFrame = "")
+
 
 
         bCurrentFixAes = bFixAes 'Warning/Question/Task: this is not flexible enough. Some of the aesthetics are set in the options. They cannot be editted on the main, however when coming back to options these are fixed and so cannot be editted anywhere anymore. Would need to be able to choose which aesthetics among a Layer should be fixed maybe.
@@ -119,7 +119,7 @@ Public Class UcrGeomListWithParameters
     Private Function LocalAndGlobalDataFramesAreDifferent() As Boolean
         'This methods checks whether the dataframe used for this layer is different from the global dataframe. If they are different, then chkIgnoreGlobalAes should be permanently checked. See UcrSelector_DataFrameChanged.
         Dim bValue As Boolean = False
-        If strGlobalDataFrame <> "" AndAlso UcrSelector.strCurrentDataFrame <> strGlobalDataFrame Then 'Warning: if the CurrentDataframe is chosen appropriately 
+        If strGlobalDataFrame <> "" AndAlso UcrSelector.strCurrentDataFrame <> strGlobalDataFrame Then 'Warning: if the CurrentDataframe is chosen appropriately, which is the case thanks to InitialiseSelectedDataFrame
             bValue = True
         End If
         Return bValue
@@ -133,6 +133,7 @@ Public Class UcrGeomListWithParameters
         For i = 0 To clsCurrGeom.clsAesParameters.Count - 1
             'Clear the potentially up to date content of the Aesthetics receivers. If the content of lstAesParameterUcr(i) is still relevant, then one of the parameters's name in clsGgplotAesFunction will match lstCurrArguments(i) and the value recovered accordingly.
             'Warning/Question: when geom is changed, local aes of previous geom are not kept. Is that fine ? Could change the method for layer to remember the previous selection for common aes between the two geoms.
+            'Warning: the order in which the two following are called counts as clearing only operates when ucr is enabled. Not that this sub will always enable all ucr's that were previously disabled.
             lstAesParameterUcr(i).Enabled = True
             lstAesParameterUcr(i).Clear()
             'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers.
@@ -265,7 +266,7 @@ Public Class UcrGeomListWithParameters
 
     Private Sub chkChangeAes_CheckedChanged(sender As Object, e As EventArgs) Handles chkApplyOnAllLayers.CheckedChanged
         'Sets the dataframe to the globaldataframe and fixes it in case that one is not empty and chkApplyOnAllLayers is checked.
-        'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"...
+        'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"... See issue on github... All this should be revised when linking is studied.
         UcrSelector.SetDataframe(strGlobalDataFrame, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         'Warning: the dataframe needs to be set first. Indeed, this will enable IgnoreGlobalAes in the "datafram_changed" sub. In the same sub, Ignore global aes will be unticked and thus setAes called. If not done in this order, Ignore global aes is unticked below before the check box has been enabled and thus the event IngnoreGlobalAes.check.changed is not raised, and set aes never called.
         If chkApplyOnAllLayers.Checked Then
@@ -287,16 +288,13 @@ Public Class UcrGeomListWithParameters
     End Sub
 
     Private Sub UcrSelector_DataFrameChanged() Handles UcrSelector.DataFrameChanged
-        'When the dataframes in local layers don't correspond to the data in the global layer, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
+        'When the dataframes in local layers don't correspond to the data in the global ggplot function, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
         If LocalAndGlobalDataFramesAreDifferent() Then
             chkIgnoreGlobalAes.Checked = True
             chkIgnoreGlobalAes.Enabled = False
-            'chkApplyOnAllLayers.Enabled = False 'Proposal 
         Else
             chkIgnoreGlobalAes.Enabled = True
-            'chkApplyOnAllLayers.Enabled = True 'Proposal
             chkIgnoreGlobalAes.Checked = False 'Warning, if IgnoreGlobalAes was checked before changing dataframe and coming back, then it will be unchecked now...
-
         End If
         'Note SetAes will be called automatically if chkIgnoreGlobalAes.checked has been changed.
     End Sub

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -264,15 +264,16 @@ Public Class UcrGeomListWithParameters
     End Function
 
     Private Sub chkChangeAes_CheckedChanged(sender As Object, e As EventArgs) Handles chkApplyOnAllLayers.CheckedChanged
+        'Sets the dataframe to the globaldataframe and fixes it in case that one is not empty and chkApplyOnAllLayers is checked.
+        'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"...
+        UcrSelector.SetDataframe(strGlobalDataFrame, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
+        'Warning: the dataframe needs to be set first. Indeed, this will enable IgnoreGlobalAes in the "datafram_changed" sub. In the same sub, Ignore global aes will be unticked and thus setAes called. If not done in this order, Ignore global aes is unticked below before the check box has been enabled and thus the event IngnoreGlobalAes.check.changed is not raised, and set aes never called.
         If chkApplyOnAllLayers.Checked Then
             chkIgnoreGlobalAes.Checked = False
             chkIgnoreGlobalAes.Hide()
         Else
             chkIgnoreGlobalAes.Show()
         End If
-        'Sets the dataframe to the globaldataframe and fixes it in case that one is not empty and chkApplyOnAllLayers is checked.
-        'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"...
-        UcrSelector.SetDataframe(strGlobalDataFrame, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
     End Sub
 
     Private Sub chkIgnoreGlobalAes_CheckedChanged(sender As Object, e As EventArgs) Handles chkIgnoreGlobalAes.CheckedChanged

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -289,10 +289,13 @@ Public Class UcrGeomListWithParameters
         'When the dataframes in local layers don't correspond to the data in the global layer, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
         If LocalAndGlobalDataFramesAreDifferent() Then
             chkIgnoreGlobalAes.Checked = True
-            chkIgnoreGlobalAes.Enabled = False
+            'chkIgnoreGlobalAes.Enabled = False 'Proposal 
+            chkApplyOnAllLayers.Enabled = False
         Else
             chkIgnoreGlobalAes.Enabled = True
+            'chkApplyOnAllLayers.Enabled = True 'Proposal
             chkIgnoreGlobalAes.Checked = False 'Warning, if IgnoreGlobalAes was checked before changing dataframe and coming back, then it will be unchecked now...
+
         End If
         'Note SetAes will be called automatically if chkIgnoreGlobalAes.checked has been changed.
     End Sub

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -119,7 +119,7 @@ Public Class UcrGeomListWithParameters
     End Sub
 
     Private Function LocalAndGlobalDataFramesAreDifferent() As Boolean
-        'This methods checks whether the dataframe used for this layer is different from the global dataframe. If they are different, then chkIgnoreGlobalAes should be permanently checked. See UcrSelector_DataFrameChanged.
+        'This methods checks whether the dataframe used for this layer is different from the global dataframe. If they are different, then chkIgnoreGlobalAes is checked. See UcrSelector_DataFrameChanged. Might also be used to print global aes in red when dataframes are different.
         Dim bValue As Boolean = False
         If strGlobalDataFrame <> "" AndAlso ucrGeomWithAesSelector.strCurrentDataFrame <> strGlobalDataFrame Then 'Warning: if the CurrentDataframe is chosen appropriately, which is the case thanks to InitialiseSelectedDataFrame
             bValue = True
@@ -139,6 +139,7 @@ Public Class UcrGeomListWithParameters
             lstAesParameterUcr(i).Enabled = True
             lstAesParameterUcr(i).Clear()
             'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers.
+            'Task: print global aesthetics in blue within the receivers and perhaps global aesthetics inherited from another dataframe in red ?
             If Not chkIgnoreGlobalAes.Checked Then
                 For Each clsParam In clsGgplotAesFunction.clsParameters
                     If clsParam.strArgumentName = lstCurrArguments(i) Then
@@ -290,14 +291,15 @@ Public Class UcrGeomListWithParameters
     End Sub
 
     Private Sub ucrGeomWithAesSelector_DataFrameChanged() Handles ucrGeomWithAesSelector.DataFrameChanged
-        'When the dataframes in local layers don't correspond to the data in the global ggplot function, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
+        'Warning: When the dataframes in local layers don't correspond to the data in the global ggplot function, inherit.aes should be set to false unless variables have the same name in different dataframes...
         'Warning: in ggplot, one can work with data1 in the global ggplot function and data2 in some layer. If the parameter inherit.aes is not set to false, the mapping in ggplot function will be copied into the layer with different dataframe. Unless the variables used in data1 are also variables in data2, this will give an error and crash the software... 
         If LocalAndGlobalDataFramesAreDifferent() Then
             chkIgnoreGlobalAes.Checked = True
-            'chkIgnoreGlobalAes.Enabled = False
+
         Else
-            chkIgnoreGlobalAes.Enabled = True
-            chkIgnoreGlobalAes.Checked = False 'Warning, if IgnoreGlobalAes was checked before changing dataframe and coming back, then it will be unchecked now...
+            'Task: add a warning message explaining the situation to the user when warning messages will have been implemented homogenuously through out the software...
+
+            'chkIgnoreGlobalAes.Checked = False 'Warning, if IgnoreGlobalAes was checked before changing dataframe and coming back, then it will be unchecked now...
         End If
         'Note SetAes will be called automatically if chkIgnoreGlobalAes.checked has been changed.
     End Sub

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -74,17 +74,16 @@ Public Class UcrGeomListWithParameters
     Private Sub InitialiseSelectedDataFrame()
         'When setting up the ucrGeomListWithAes, we want the selected dataframe to be the one used in the clsGeomFunction that has been given through. This is also needed for the method in LocalAndGlobalDataFramesAreDifferent() to work when editing a layer.
         Dim strDataFrameName As String = strGlobalDataFrame
-        Dim strParameterValue As String
         Dim iIndexOfData_nameParameter As Integer
         If clsGeomFunction.GetParameter("data") IsNot Nothing AndAlso clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name") <> -1 Then
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
-            strParameterValue = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue
-            strDataFrameName = String.Copy(strParameterValue)
+            strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue)
             strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2)
             UcrSelector.SetDataframe(strDataFrameName)
         Else
             UcrSelector.SetDataframe(strDataFrameName, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         End If
+
     End Sub
     Public Overrides Sub Setup(clsTempGgPlot As RFunction, clsTempGeomFunc As RFunction, clsTempGlobalAesFunc As RFunction, Optional bFixAes As Boolean = False, Optional bFixGeom As Boolean = False, Optional strDataframe As String = "", Optional bApplyAesGlobally As Boolean = True, Optional bIgnoreGlobalAes As Boolean = False, Optional iNumVariablesForGeoms As Integer = -1, Optional clsTempLocalAes As RFunction = Nothing)
         'See ucrAdditionalLayers and Specific Plots dlg to see how the SetUp Parameters are chosen within the sdgLayerOptions.SetupLayer call.
@@ -275,6 +274,7 @@ Public Class UcrGeomListWithParameters
             chkIgnoreGlobalAes.Show()
         End If
         'Sets the dataframe to the globaldataframe and fixes it in case that one is not empty and chkApplyOnAllLayers is checked.
+        'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"...
         UcrSelector.SetDataframe(strGlobalDataFrame, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
     End Sub
 

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -80,7 +80,7 @@ Public Class UcrGeomListWithParameters
         If clsGeomFunction.GetParameter("data") IsNot Nothing AndAlso clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name") <> -1 Then
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
             strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue) 'Note: copy is supposidely necessary here to avoid editing the value of the "data_name" parameter in clsArgumentFunction (in any case it doesn't do any harm).
-            strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2) 'The value of the parameter "data_name" has quotes around it hat need to be erased as we merely want the name of the data_frame.
+            strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2) 'The value of the parameter "data_name" has quotes around it that need to be erased as we merely want the name of the data_frame.
             ucrGeomWithAesSelector.SetDataframe(strDataFrameName)
         Else
             ucrGeomWithAesSelector.SetDataframe(strDataFrameName, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -76,10 +76,10 @@ Public Class UcrGeomListWithParameters
         Dim strDataFrameName As String
         Dim iIndexOfData_nameParameter As Integer
 
-        strDataFrameName = String.Copy(strGlobalDataFrame)
+        strDataFrameName = strGlobalDataFrame
         If clsGeomFunction.GetParameter("data") IsNot Nothing AndAlso clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name") <> -1 Then
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
-            strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue) 'Note: copy is supposidely necessary here to avoid editing the value of the "data_name" parameter in clsArgumentFunction (in any case it doesn't do any harm).
+            strDataFrameName = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue
             strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2) 'The value of the parameter "data_name" has quotes around it that need to be erased as we merely want the name of the data_frame.
             ucrGeomWithAesSelector.SetDataframe(strDataFrameName)
         Else

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -27,7 +27,6 @@ Public Class UcrGeomListWithParameters
     Public ucrLayersControl As ucrLayerParameters
     Public bCheckEnabled As Boolean = True
     Public Event DataFrameChanged()
-    Public clsGgplotFunction As New RFunction
     Public clsGeomAesFunction As RFunction
     'clsGeomAesFunction stores the value (aes function) of the local mapping (of this particular layer). It is used as parameter in sdgLayerOptions.clsGeomFunction.
     Public bAddToLocalAes As Boolean = True
@@ -97,7 +96,6 @@ Public Class UcrGeomListWithParameters
             clsGeomAesFunction = New RFunction
             clsGeomAesFunction.SetRCommand("aes")
         End If
-        clsGgplotFunction = clsTempGgPlot
 
         'Using the values of the two relevant parameters, the two following lines determine whether the chkBoxes ApplyToAllLayers and IgnoreGlobalAes should be ticked. 
         'Introduced a safety net: these can't be ticked at the same time, in that case an error has been made in the code and a message is sent to the user.
@@ -141,7 +139,7 @@ Public Class UcrGeomListWithParameters
             'Warning/Question: when geom is changed, local aes of previous geom are not kept. Is that fine ? Could change the method for layer to remember the previous selection for common aes between the two geoms.
             lstAesParameterUcr(i).Clear()
             lstAesParameterUcr(i).Enabled = True
-            'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers. Also, when the dataframe is not the same for global ggplot and local geom, then aesthetics mappings shouldn't be copied... At this point clsGgplotFunction should be nonempty ...
+            'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers.
             If Not chkIgnoreGlobalAes.Checked Then
                 For Each clsParam In clsGgplotAesFunction.clsParameters
                     If clsParam.strArgumentName = lstCurrArguments(i) Then

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -198,7 +198,7 @@ Public Class UcrGeomListWithParameters
                 lstAesParameterLabels(i).Visible = True
                 lstAesParameterUcr(i).Visible = True
 
-                lstAesParameterLabels(i).Text = clsCurrGeom.clsAesParameters(i).strAesParameterName
+                lstAesParameterLabels(i).Text = clsCurrGeom.clsAesParameters(i).strAesParameterName & ":"
                 lstCurrArguments.Add(clsCurrGeom.clsAesParameters(i).strAesParameterName)
                 lstAesParameterUcr(i).Clear()
                 If clsCurrGeom.clsAesParameters(i).bIsMandatory Then

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -79,7 +79,7 @@ Public Class UcrGeomListWithParameters
         strDataFrameName = String.Copy(strGlobalDataFrame)
         If clsGeomFunction.GetParameter("data") IsNot Nothing AndAlso clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name") <> -1 Then
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
-            strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue) 'Note: copy is necessary herre to avoid editing the value of the "data_name" parameter in clsArgumentFunction (in any case it doesn't do any harm).
+            strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue) 'Note: copy is supposidely necessary here to avoid editing the value of the "data_name" parameter in clsArgumentFunction (in any case it doesn't do any harm).
             strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2) 'The value of the parameter "data_name" has quotes around it hat need to be erased as we merely want the name of the data_frame.
             ucrGeomWithAesSelector.SetDataframe(strDataFrameName)
         Else
@@ -107,7 +107,7 @@ Public Class UcrGeomListWithParameters
         chkApplyOnAllLayers.Checked = bApplyAesGlobally
         chkIgnoreGlobalAes.Checked = bIgnoreGlobalAes 'Note: raises the event check changed if the value has indeed changed.
 
-        'UcrSelector.Reset() 'Warning: Not sure this is necessary anymore... Testing will confirm.
+        'ucrGeomWithAesSelector.Reset() 'Warning: Not sure this is necessary anymore... Testing will confirm.
         InitialiseSelectedDataFrame()
 
 

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -73,12 +73,14 @@ Public Class UcrGeomListWithParameters
 
     Private Sub InitialiseSelectedDataFrame()
         'When setting up the ucrGeomListWithAes, we want the selected dataframe to be the one used in the clsGeomFunction that has been given through. This is also needed for the method in LocalAndGlobalDataFramesAreDifferent() to work when editing a layer.
-        Dim strDataFrameName As String = String.Copy(strGlobalDataFrame)
+        Dim strDataFrameName As String
         Dim iIndexOfData_nameParameter As Integer
+
+        strDataFrameName = String.Copy(strGlobalDataFrame)
         If clsGeomFunction.GetParameter("data") IsNot Nothing AndAlso clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name") <> -1 Then
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
-            strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue)
-            strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2)
+            strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue) 'Note: copy is necessary herre to avoid editing the value of the "data_name" parameter in clsArgumentFunction (in any case it doesn't do any harm).
+            strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2) 'The value of the parameter "data_name" has quotes around it hat need to be erased as we merely want the name of the data_frame.
             ucrGeomWithAesSelector.SetDataframe(strDataFrameName)
         Else
             ucrGeomWithAesSelector.SetDataframe(strDataFrameName, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
@@ -289,9 +291,10 @@ Public Class UcrGeomListWithParameters
 
     Private Sub ucrGeomWithAesSelector_DataFrameChanged() Handles ucrGeomWithAesSelector.DataFrameChanged
         'When the dataframes in local layers don't correspond to the data in the global ggplot function, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
+        'Warning: in ggplot, one can work with data1 in the global ggplot function and data2 in some layer. If the parameter inherit.aes is not set to false, the mapping in ggplot function will be copied into the layer with different dataframe. Unless the variables used in data1 are also variables in data2, this will give an error and crash the software... 
         If LocalAndGlobalDataFramesAreDifferent() Then
             chkIgnoreGlobalAes.Checked = True
-            chkIgnoreGlobalAes.Enabled = False
+            'chkIgnoreGlobalAes.Enabled = False
         Else
             chkIgnoreGlobalAes.Enabled = True
             chkIgnoreGlobalAes.Checked = False 'Warning, if IgnoreGlobalAes was checked before changing dataframe and coming back, then it will be unchecked now...

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -27,6 +27,7 @@ Public Class UcrGeomListWithParameters
     Public ucrLayersControl As ucrLayerParameters
     Public bCheckEnabled As Boolean = True
     Public Event DataFrameChanged()
+    Public clsGgplotFunction As New RFunction
     Public clsGeomAesFunction As RFunction
     'clsGeomAesFunction stores the value (aes function) of the local mapping (of this particular layer). It is used as parameter in sdgLayerOptions.clsGeomFunction.
     Public bAddToLocalAes As Boolean = True
@@ -81,6 +82,7 @@ Public Class UcrGeomListWithParameters
             clsGeomAesFunction = New RFunction
             clsGeomAesFunction.SetRCommand("aes")
         End If
+        clsGgplotFunction = clsTempGgPlot
         UcrSelector.SetDataframe(strGlobalDataFrame, (Not bApplyAesGlobally) OrElse strGlobalDataFrame = "")
         UcrSelector.Reset()
 
@@ -111,8 +113,8 @@ Public Class UcrGeomListWithParameters
             'Warning/Question: when geom is changed, local aes of previous geom are not kept. Is that fine ? Could change the method for layer to remember the previous selection for common aes between the two geoms.
             lstAesParameterUcr(i).Clear()
             lstAesParameterUcr(i).Enabled = True
-            'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers.
-            If Not chkIgnoreGlobalAes.Checked Then
+            'When IgnoreGlobalAes is checked, we don't want the global aesthetics to appear in the receivers. Also, when the dataframe is not the same for global ggplot and local geom, then aesthetics mappings shouldn't be copied... At this point clsGgplotFunction should be nonempty ...
+            If (Not chkIgnoreGlobalAes.Checked) AndAlso Not (clsGeomFunction.GetParameter("mapping") IsNot Nothing AndAlso clsGgplotFunction.GetParameter("mapping") IsNot Nothing AndAlso clsGeomFunction.GetParameter("mapping").strArgumentValue <> clsGgplotFunction.GetParameter("mapping").strArgumentValue) Then
                 For Each clsParam In clsGgplotAesFunction.clsParameters
                     If clsParam.strArgumentName = lstCurrArguments(i) Then
                         'For some geoms like LinePlot, when the x or y aes is not filled, ggplot R syntax requires to set x="". This x="" might be copied into the global aes if the ApplyOnAllLayers is set to true for a BoxPlot Layer. This might be copied from the GgplotAesFunction parameters into the aes receivers by error in subsequent layers.

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -289,8 +289,8 @@ Public Class UcrGeomListWithParameters
         'When the dataframes in local layers don't correspond to the data in the global layer, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
         If LocalAndGlobalDataFramesAreDifferent() Then
             chkIgnoreGlobalAes.Checked = True
-            'chkIgnoreGlobalAes.Enabled = False 'Proposal 
-            chkApplyOnAllLayers.Enabled = False
+            chkIgnoreGlobalAes.Enabled = False
+            'chkApplyOnAllLayers.Enabled = False 'Proposal 
         Else
             chkIgnoreGlobalAes.Enabled = True
             'chkApplyOnAllLayers.Enabled = True 'Proposal

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -97,6 +97,9 @@ Public Class UcrGeomListWithParameters
             clsGeomAesFunction.SetRCommand("aes")
         End If
 
+        'ucrGeomWithAesSelector.Reset() 'Warning: Not sure this is necessary anymore... Testing will confirm.
+        InitialiseSelectedDataFrame()
+
         'Using the values of the two relevant parameters, the two following lines determine whether the chkBoxes ApplyToAllLayers and IgnoreGlobalAes should be ticked. 
         'Introduced a safety net: these can't be ticked at the same time, in that case an error has been made in the code and a message is sent to the user.
         If bApplyAesGlobally AndAlso bIgnoreGlobalAes Then
@@ -107,8 +110,7 @@ Public Class UcrGeomListWithParameters
         chkApplyOnAllLayers.Checked = bApplyAesGlobally
         chkIgnoreGlobalAes.Checked = bIgnoreGlobalAes 'Note: raises the event check changed if the value has indeed changed.
 
-        'ucrGeomWithAesSelector.Reset() 'Warning: Not sure this is necessary anymore... Testing will confirm.
-        InitialiseSelectedDataFrame()
+
 
 
 

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -59,16 +59,16 @@ Public Class UcrGeomListWithParameters
 
     Private Sub SetSelector()
         'Link the selector and the receivers
-        ucrReceiverParam1.Selector = UcrSelector
-        ucrReceiverParam2.Selector = UcrSelector
-        ucrReceiverParam3.Selector = UcrSelector
-        ucrReceiverParam4.Selector = UcrSelector
-        ucrReceiverParam5.Selector = UcrSelector
-        ucrReceiverParam6.Selector = UcrSelector
-        ucrReceiverParam7.Selector = UcrSelector
-        ucrReceiverParam8.Selector = UcrSelector
-        ucrReceiverParam9.Selector = UcrSelector
-        ucrReceiverParam10.Selector = UcrSelector
+        ucrReceiverParam1.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam2.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam3.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam4.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam5.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam6.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam7.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam8.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam9.Selector = ucrGeomWithAesSelector
+        ucrReceiverParam10.Selector = ucrGeomWithAesSelector
     End Sub
 
     Private Sub InitialiseSelectedDataFrame()
@@ -79,9 +79,9 @@ Public Class UcrGeomListWithParameters
             iIndexOfData_nameParameter = clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "data_name")
             strDataFrameName = String.Copy(clsGeomFunction.GetParameter("data").clsArgumentFunction.clsParameters(iIndexOfData_nameParameter).strArgumentValue)
             strDataFrameName = strDataFrameName.Substring(1, strDataFrameName.Length - 2)
-            UcrSelector.SetDataframe(strDataFrameName)
+            ucrGeomWithAesSelector.SetDataframe(strDataFrameName)
         Else
-            UcrSelector.SetDataframe(strDataFrameName, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
+            ucrGeomWithAesSelector.SetDataframe(strDataFrameName, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         End If
     End Sub
     Public Overrides Sub Setup(clsTempGgPlot As RFunction, clsTempGeomFunc As RFunction, clsTempGlobalAesFunc As RFunction, Optional bFixAes As Boolean = False, Optional bFixGeom As Boolean = False, Optional strDataframe As String = "", Optional bApplyAesGlobally As Boolean = True, Optional bIgnoreGlobalAes As Boolean = False, Optional iNumVariablesForGeoms As Integer = -1, Optional clsTempLocalAes As RFunction = Nothing)
@@ -119,7 +119,7 @@ Public Class UcrGeomListWithParameters
     Private Function LocalAndGlobalDataFramesAreDifferent() As Boolean
         'This methods checks whether the dataframe used for this layer is different from the global dataframe. If they are different, then chkIgnoreGlobalAes should be permanently checked. See UcrSelector_DataFrameChanged.
         Dim bValue As Boolean = False
-        If strGlobalDataFrame <> "" AndAlso UcrSelector.strCurrentDataFrame <> strGlobalDataFrame Then 'Warning: if the CurrentDataframe is chosen appropriately, which is the case thanks to InitialiseSelectedDataFrame
+        If strGlobalDataFrame <> "" AndAlso ucrGeomWithAesSelector.strCurrentDataFrame <> strGlobalDataFrame Then 'Warning: if the CurrentDataframe is chosen appropriately, which is the case thanks to InitialiseSelectedDataFrame
             bValue = True
         End If
         Return bValue
@@ -267,7 +267,7 @@ Public Class UcrGeomListWithParameters
     Private Sub chkChangeAes_CheckedChanged(sender As Object, e As EventArgs) Handles chkApplyOnAllLayers.CheckedChanged
         'Sets the dataframe to the globaldataframe and fixes it in case that one is not empty and chkApplyOnAllLayers is checked.
         'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"... See issue on github... All this should be revised when linking is studied.
-        UcrSelector.SetDataframe(strGlobalDataFrame, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
+        ucrGeomWithAesSelector.SetDataframe(strGlobalDataFrame, (Not chkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         'Warning: the dataframe needs to be set first. Indeed, this will enable IgnoreGlobalAes in the "datafram_changed" sub. In the same sub, Ignore global aes will be unticked and thus setAes called. If not done in this order, Ignore global aes is unticked below before the check box has been enabled and thus the event IngnoreGlobalAes.check.changed is not raised, and set aes never called.
         If chkApplyOnAllLayers.Checked Then
             chkIgnoreGlobalAes.Checked = False
@@ -287,7 +287,7 @@ Public Class UcrGeomListWithParameters
         SetAes()
     End Sub
 
-    Private Sub UcrSelector_DataFrameChanged() Handles UcrSelector.DataFrameChanged
+    Private Sub ucrGeomWithAesSelector_DataFrameChanged() Handles ucrGeomWithAesSelector.DataFrameChanged
         'When the dataframes in local layers don't correspond to the data in the global ggplot function, inherit.aes should be set to false (otherwise risk for errors). Then the IgnoreGlobalAes should remain ticked until dataframes coincide.
         If LocalAndGlobalDataFramesAreDifferent() Then
             chkIgnoreGlobalAes.Checked = True

--- a/instat/dlgGeneralForGraphics.vb
+++ b/instat/dlgGeneralForGraphics.vb
@@ -46,7 +46,7 @@ Public Class dlgGeneralForGraphics
         'True for "we are setting the first parameter, on the left of +".
         ucrBase.iHelpTopicID = 356
 
-        ucrSaveGraph.SetDataFrameSelector(sdgLayerOptions.ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames)
+        ucrSaveGraph.SetDataFrameSelector(sdgLayerOptions.ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames)
         ucrSaveGraph.strPrefix = "Graph"
         ucrAdditionalLayers.SetRSyntax(ucrBase.clsRsyntax)
         ucrAdditionalLayers.SetGGplotFunction(clsRggplotFunction)
@@ -165,9 +165,9 @@ Public Class dlgGeneralForGraphics
 
     Private Sub ucrSaveGraph_GraphNameChanged() Handles ucrSaveGraph.GraphNameChanged, ucrSaveGraph.SaveGraphCheckedChanged
         If ucrSaveGraph.bSaveGraph Then
-            ucrBase.clsRsyntax.SetAssignTo(ucrSaveGraph.strGraphName, strTempDataframe:=sdgLayerOptions.ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:=ucrSaveGraph.strGraphName)
+            ucrBase.clsRsyntax.SetAssignTo(ucrSaveGraph.strGraphName, strTempDataframe:=sdgLayerOptions.ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:=ucrSaveGraph.strGraphName)
         Else
-            ucrBase.clsRsyntax.SetAssignTo("last_graph", strTempDataframe:=sdgLayerOptions.ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
+            ucrBase.clsRsyntax.SetAssignTo("last_graph", strTempDataframe:=sdgLayerOptions.ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strTempGraph:="last_graph")
         End If
     End Sub
 

--- a/instat/sdgLayerOptions.vb
+++ b/instat/sdgLayerOptions.vb
@@ -90,9 +90,10 @@ Public Class sdgLayerOptions
             clsGgplotFunction.AddParameter("data", clsRFunctionParameter:=ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.clsCurrDataFrame.Clone())
             'The data frame that is selected in the dataframe selector (lives in ucrGeomWithAes) is communicated to the sdgLayerOptions and the ucrGeomWithAes
             'Question to be discussed: could these two strGlobalDataFrame and ucrGeomWithAes.strGlobalDataFrame not be linked together in sdgLayerOptions.initialisedialog() ? 
+            'Question: why do we even do this ? Should it not have been done earlier ? What's the point of changing parameters on sdgLayerOptions right before closing it ?
             strGlobalDataFrame = ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text
             ucrGeomWithAes.strGlobalDataFrame = strGlobalDataFrame
-        Else
+        Else 'Warning: in case the dggLayerOptions has been called by specific dlg, need to refill the aes on that dlg. Imagine the ApplyOnAllLayers has been unticked ? Problem... Also in order to solve this, would need to know on the specific dialog if it has been unticked or not in order to know how to fill in the aes receivers !
             If ucrGeomWithAes.clsGeomAesFunction.iParameterCount > 0 Then
                 clsGeomFunction.AddParameter("mapping", clsRFunctionParameter:=ucrGeomWithAes.clsGeomAesFunction.Clone())
             Else

--- a/instat/sdgLayerOptions.vb
+++ b/instat/sdgLayerOptions.vb
@@ -93,7 +93,7 @@ Public Class sdgLayerOptions
             'Question: why do we even do this ? Should it not have been done earlier ? What's the point of changing parameters on sdgLayerOptions right before closing it ?
             strGlobalDataFrame = ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text
             ucrGeomWithAes.strGlobalDataFrame = strGlobalDataFrame
-        Else 'Warning: in case the dggLayerOptions has been called by specific dlg, need to refill the aes on that dlg. Imagine the ApplyOnAllLayers has been unticked ? Problem... Also in order to solve this, would need to know on the specific dialog if it has been unticked or not in order to know how to fill in the aes receivers ! Or could disable Ignore and Apply on all layers when coming from specific plots as suggested before. Don't remember why we deleted it.
+        Else 'Warning: in case the dggLayerOptions has been called by specific dlg, need to refill the aes on that dlg. Imagine the ApplyOnAllLayers has been unticked ? Problem... Also in order to solve this, would need to know on the specific dialog if it has been unticked or not in order to know how to fill in the aes receivers ! The linking will be restudied anyway. There are many ways to go, see discussion on github.
             If ucrGeomWithAes.clsGeomAesFunction.iParameterCount > 0 Then
                 clsGeomFunction.AddParameter("mapping", clsRFunctionParameter:=ucrGeomWithAes.clsGeomAesFunction.Clone())
             Else
@@ -106,8 +106,8 @@ Public Class sdgLayerOptions
             End If
         End If
         If clsGeomFunction.strRCommand = "geom_bar" OrElse clsGeomFunction.strRCommand = "geom_density" OrElse clsGeomFunction.strRCommand = "geom_freqpoly" Then
-            'Warning: this is not working quite ok yet. Got some bad behaviour when "" comes from global aes, but is overwritten I think. Will tidy this up when introducing partially mandatory aesthetics method.
-            If (((clsAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1) AndAlso ((clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "inherit.aes") = -1) OrElse (clsGeomFunction.GetParameter("inherit.aes").strArgumentValue = "FALSE"))) OrElse (ucrGeomWithAes.clsGeomAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1)) AndAlso (clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "stat") = -1) Then
+            'If there is a y in the global aes, and the global aes are not ignored or if there is a y in the local aes then in case stat has not been set manually, stat is set to identity.
+            If (((clsAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1) AndAlso ((clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "inherit.aes") = -1) OrElse (clsGeomFunction.GetParameter("inherit.aes").strArgumentValue = "TRUE"))) OrElse (ucrGeomWithAes.clsGeomAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1)) AndAlso (clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "stat") = -1) Then
                 clsGeomFunction.AddParameter("stat", Chr(34) & "identity" & Chr(34))
             End If
             If clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "stat") <> -1 Then

--- a/instat/sdgLayerOptions.vb
+++ b/instat/sdgLayerOptions.vb
@@ -50,7 +50,7 @@ Public Class sdgLayerOptions
     End Sub
 
     Private Sub SetDefaults()
-        ucrGeomWithAes.UcrSelector.Reset()
+        ucrGeomWithAes.ucrGeomWithAesSelector.Reset()
         strGlobalDataFrame = ""
     End Sub
 
@@ -87,11 +87,11 @@ Public Class sdgLayerOptions
             clsGeomFunction.RemoveParameterByName("data")
             'Here the global ggplot function takes the relevant "mapping" and "data" parameters as required by "ApplyOnAllLayers".
             clsGgplotFunction.AddParameter("mapping", clsRFunctionParameter:=clsAesFunction)
-            clsGgplotFunction.AddParameter("data", clsRFunctionParameter:=ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.clsCurrDataFrame.Clone())
+            clsGgplotFunction.AddParameter("data", clsRFunctionParameter:=ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames.clsCurrDataFrame.Clone())
             'The data frame that is selected in the dataframe selector (lives in ucrGeomWithAes) is communicated to the sdgLayerOptions and the ucrGeomWithAes
             'Question to be discussed: could these two strGlobalDataFrame and ucrGeomWithAes.strGlobalDataFrame not be linked together in sdgLayerOptions.initialisedialog() ? 
             'Question: why do we even do this ? Should it not have been done earlier ? What's the point of changing parameters on sdgLayerOptions right before closing it ?
-            strGlobalDataFrame = ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text
+            strGlobalDataFrame = ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text
             ucrGeomWithAes.strGlobalDataFrame = strGlobalDataFrame
         Else 'Warning: in case the dggLayerOptions has been called by specific dlg, need to refill the aes on that dlg. Imagine the ApplyOnAllLayers has been unticked ? Problem... Also in order to solve this, would need to know on the specific dialog if it has been unticked or not in order to know how to fill in the aes receivers ! The linking will be restudied anyway. There are many ways to go, see discussion on github.
             If ucrGeomWithAes.clsGeomAesFunction.iParameterCount > 0 Then
@@ -99,8 +99,8 @@ Public Class sdgLayerOptions
             Else
                 clsGeomFunction.RemoveParameterByName("mapping")
             End If
-            If ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text <> strGlobalDataFrame Then
-                clsGeomFunction.AddParameter("data", clsRFunctionParameter:=ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.clsCurrDataFrame.Clone())
+            If ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text <> strGlobalDataFrame Then
+                clsGeomFunction.AddParameter("data", clsRFunctionParameter:=ucrGeomWithAes.ucrGeomWithAesSelector.ucrAvailableDataFrames.clsCurrDataFrame.Clone())
             Else
                 clsGeomFunction.RemoveParameterByName("data")
             End If

--- a/instat/sdgLayerOptions.vb
+++ b/instat/sdgLayerOptions.vb
@@ -93,7 +93,7 @@ Public Class sdgLayerOptions
             'Question: why do we even do this ? Should it not have been done earlier ? What's the point of changing parameters on sdgLayerOptions right before closing it ?
             strGlobalDataFrame = ucrGeomWithAes.UcrSelector.ucrAvailableDataFrames.cboAvailableDataFrames.Text
             ucrGeomWithAes.strGlobalDataFrame = strGlobalDataFrame
-        Else 'Warning: in case the dggLayerOptions has been called by specific dlg, need to refill the aes on that dlg. Imagine the ApplyOnAllLayers has been unticked ? Problem... Also in order to solve this, would need to know on the specific dialog if it has been unticked or not in order to know how to fill in the aes receivers !
+        Else 'Warning: in case the dggLayerOptions has been called by specific dlg, need to refill the aes on that dlg. Imagine the ApplyOnAllLayers has been unticked ? Problem... Also in order to solve this, would need to know on the specific dialog if it has been unticked or not in order to know how to fill in the aes receivers ! Or could disable Ignore and Apply on all layers when coming from specific plots as suggested before. Don't remember why we deleted it.
             If ucrGeomWithAes.clsGeomAesFunction.iParameterCount > 0 Then
                 clsGeomFunction.AddParameter("mapping", clsRFunctionParameter:=ucrGeomWithAes.clsGeomAesFunction.Clone())
             Else

--- a/instat/sdgLayerOptions.vb
+++ b/instat/sdgLayerOptions.vb
@@ -106,7 +106,7 @@ Public Class sdgLayerOptions
         End If
         If clsGeomFunction.strRCommand = "geom_bar" OrElse clsGeomFunction.strRCommand = "geom_density" OrElse clsGeomFunction.strRCommand = "geom_freqpoly" Then
             'Warning: this is not working quite ok yet. Got some bad behaviour when "" comes from global aes, but is overwritten I think. Will tidy this up when introducing partially mandatory aesthetics method.
-            If (clsAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1 AndAlso ((clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "inherit.aes") = -1) OrElse (clsGeomFunction.GetParameter("inherit.aes").strArgumentValue = "TRUE")) OrElse (ucrGeomWithAes.clsGeomAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1)) AndAlso (clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "stat") = -1) Then
+            If (((clsAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1) AndAlso ((clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "inherit.aes") = -1) OrElse (clsGeomFunction.GetParameter("inherit.aes").strArgumentValue = "FALSE"))) OrElse (ucrGeomWithAes.clsGeomAesFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "y") <> -1)) AndAlso (clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "stat") = -1) Then
                 clsGeomFunction.AddParameter("stat", Chr(34) & "identity" & Chr(34))
             End If
             If clsGeomFunction.clsParameters.FindIndex(Function(x) x.strArgumentName = "stat") <> -1 Then

--- a/instat/sdgLayerOptions.vb
+++ b/instat/sdgLayerOptions.vb
@@ -80,7 +80,7 @@ Public Class sdgLayerOptions
         If ucrGeomWithAes.chkApplyOnAllLayers.Checked Then
             'First, in case the chkApplyOnAllLayers is checked, what is by default understood as local mapping (clsGeomAesFunction) needs to become global mapping: the Aes parameters in clsGeomAesFunction are sent through to clsAesFunction.
             For Each clsParam In ucrGeomWithAes.clsGeomAesFunction.clsParameters
-                clsAesFunction.AddParameter(clsParam)
+                clsAesFunction.AddParameter(clsParam) 'Warning: This never removes the parameters that have been previously inserted...
             Next
             'Now, we don't want the parameters "mapping" and "data" in the Layer as these will be fixed globally and then inherited.
             clsGeomFunction.RemoveParameterByName("mapping")


### PR DESCRIPTION
List of changes:

- global aes fill when difference between global and local dataframes

- adding IgnoreGlobalAes when difference between global and local dataframes

- correct the add "stat = identity" method
