### PR TITLE
Combine Text

### DIFF
--- a/instat/dlgCombineText.Designer.vb
+++ b/instat/dlgCombineText.Designer.vb
@@ -35,10 +35,10 @@ Partial Class dlgCombineText
         'lblSeparator
         '
         Me.lblSeparator.AutoSize = True
-        Me.lblSeparator.Location = New System.Drawing.Point(255, 152)
+        Me.lblSeparator.Location = New System.Drawing.Point(248, 167)
         Me.lblSeparator.Name = "lblSeparator"
         Me.lblSeparator.Size = New System.Drawing.Size(56, 13)
-        Me.lblSeparator.TabIndex = 4
+        Me.lblSeparator.TabIndex = 3
         Me.lblSeparator.Text = "Separator:"
         '
         'lblNewColumnName
@@ -54,20 +54,20 @@ Partial Class dlgCombineText
         'lblColumnsToCobine
         '
         Me.lblColumnsToCobine.AutoSize = True
-        Me.lblColumnsToCobine.Location = New System.Drawing.Point(255, 28)
+        Me.lblColumnsToCobine.Location = New System.Drawing.Point(248, 46)
         Me.lblColumnsToCobine.Name = "lblColumnsToCobine"
         Me.lblColumnsToCobine.Size = New System.Drawing.Size(106, 13)
-        Me.lblColumnsToCobine.TabIndex = 7
+        Me.lblColumnsToCobine.TabIndex = 1
         Me.lblColumnsToCobine.Tag = "Columns_to_Combine:"
         Me.lblColumnsToCobine.Text = "Columns to Combine:"
         '
         'ucrInputSeparator
         '
         Me.ucrInputSeparator.IsReadOnly = False
-        Me.ucrInputSeparator.Location = New System.Drawing.Point(255, 168)
+        Me.ucrInputSeparator.Location = New System.Drawing.Point(247, 182)
         Me.ucrInputSeparator.Name = "ucrInputSeparator"
-        Me.ucrInputSeparator.Size = New System.Drawing.Size(145, 21)
-        Me.ucrInputSeparator.TabIndex = 10
+        Me.ucrInputSeparator.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputSeparator.TabIndex = 4
         '
         'ucrInputColumnInto
         '
@@ -75,11 +75,11 @@ Partial Class dlgCombineText
         Me.ucrInputColumnInto.Location = New System.Drawing.Point(116, 209)
         Me.ucrInputColumnInto.Name = "ucrInputColumnInto"
         Me.ucrInputColumnInto.Size = New System.Drawing.Size(145, 21)
-        Me.ucrInputColumnInto.TabIndex = 9
+        Me.ucrInputColumnInto.TabIndex = 6
         '
         'ucrReceiverCombineText
         '
-        Me.ucrReceiverCombineText.Location = New System.Drawing.Point(255, 44)
+        Me.ucrReceiverCombineText.Location = New System.Drawing.Point(247, 61)
         Me.ucrReceiverCombineText.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverCombineText.Name = "ucrReceiverCombineText"
         Me.ucrReceiverCombineText.Selector = Nothing
@@ -94,20 +94,20 @@ Partial Class dlgCombineText
         Me.ucrSelectorForCombineText.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorForCombineText.Name = "ucrSelectorForCombineText"
         Me.ucrSelectorForCombineText.Size = New System.Drawing.Size(210, 180)
-        Me.ucrSelectorForCombineText.TabIndex = 1
+        Me.ucrSelectorForCombineText.TabIndex = 0
         '
         'ucrBase
         '
         Me.ucrBase.Location = New System.Drawing.Point(10, 236)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(410, 52)
-        Me.ucrBase.TabIndex = 0
+        Me.ucrBase.TabIndex = 7
         '
         'dlgCombineText
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(423, 297)
+        Me.ClientSize = New System.Drawing.Size(415, 297)
         Me.Controls.Add(Me.ucrInputSeparator)
         Me.Controls.Add(Me.ucrInputColumnInto)
         Me.Controls.Add(Me.lblColumnsToCobine)

--- a/instat/dlgCombineText.vb
+++ b/instat/dlgCombineText.vb
@@ -31,7 +31,7 @@ Public Class dlgCombineText
     End Sub
 
     Private Sub ReopenDialog()
-
+        ColumnOrder()
     End Sub
 
     Private Sub TestOKEnabled()
@@ -52,7 +52,6 @@ Public Class dlgCombineText
         ucrInputColumnInto.SetItemsTypeAsColumns()
         ucrInputColumnInto.SetDefaultTypeAsColumn()
         ucrInputColumnInto.SetDataFrameSelector(ucrSelectorForCombineText.ucrAvailableDataFrames)
-        ucrInputColumnInto.SetPrefix("Combine")
         iColumnsUsed = 0
         ucrInputSeparator.SetItems({"Space", "-", "_", "."})
         ucrBase.iHelpTopicID = 345
@@ -62,6 +61,7 @@ Public Class dlgCombineText
     Private Sub SetDefaults()
         ucrSelectorForCombineText.Reset()
         ucrSelectorForCombineText.Focus()
+        ucrInputColumnInto.SetPrefix("Combine")
         ucrInputSeparator.SetName("")
     End Sub
 
@@ -99,6 +99,11 @@ Public Class dlgCombineText
     End Sub
 
     Private Sub ucrReceiverCombineText_SelectionChanged() Handles ucrReceiverCombineText.SelectionChanged
+        ColumnOrder()
+        TestOKEnabled()
+    End Sub
+
+    Private Sub ColumnOrder()
         Dim lstColumnFunction As List(Of RFunction)
 
         For i = 1 To iColumnsUsed
@@ -112,7 +117,5 @@ Public Class dlgCombineText
                 ucrBase.clsRsyntax.AddParameter("X" & i + 1, clsRFunctionParameter:=lstColumnFunction(i))
             Next
         End If
-        TestOKEnabled()
     End Sub
-
 End Class


### PR DESCRIPTION
Name prefix in Defaults
Tab Order

Fixed Bug - upon reopening the dialog, the order of the variables to combine would flip (i.e., it would combine as ABC first time, CBA second time, ABC third, CBA, ... etc)

Bug issue - if you input variables as A B C, then it combines them as C B A always. I'm not sure how to fix this, although have been trying.



So, it was going
FIRST TIME:
Combine5 <- stringr::str_c(**X2**=InstatDataObject$get_columns_from_data(use_current_filter=FALSE, col_names="**no**", data_name="border_dataframe"), **X1**=InstatDataObject$get_columns_from_data(use_current_filter=FALSE, col_names="**dai**", data_name="border_dataframe"))

SECOND TIME:
Combine6 <- stringr::str_c(**X1**=InstatDataObject$get_columns_from_data(data_name="border_dataframe", col_names="**dai**", use_current_filter=FALSE), **X2**=InstatDataObject$get_columns_from_data(data_name="border_dataframe", col_names="**no**", use_current_filter=FALSE))




Now it doesn't flip between X1 and X2 each time, however, it constantly starts with X2.