### PR TITLE
DlgOneWayFrequencies

### DIFF
--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -22,13 +22,6 @@ Partial Class dlgOneWayFrequencies
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrReceiverOneWayFreq = New instat.ucrReceiverSingle()
-        Me.ucrSaveGraph = New instat.ucrSave()
-        Me.ucrBase = New instat.ucrButtons()
-        Me.ucrChkTable = New instat.ucrCheck()
-        Me.ucrChkweights = New instat.ucrCheck()
-        Me.ucrChkGraph = New instat.ucrCheck()
         Me.grpSort = New System.Windows.Forms.GroupBox()
         Me.rdoDescending = New System.Windows.Forms.RadioButton()
         Me.rdoAscending = New System.Windows.Forms.RadioButton()
@@ -37,66 +30,15 @@ Partial Class dlgOneWayFrequencies
         Me.cmdOptions = New System.Windows.Forms.Button()
         Me.lblSelectedVariable = New System.Windows.Forms.Label()
         Me.ucrChkFlip = New instat.ucrCheck()
+        Me.ucrChkGraph = New instat.ucrCheck()
+        Me.ucrChkTable = New instat.ucrCheck()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSaveGraph = New instat.ucrSave()
+        Me.ucrReceiverOneWayFreq = New instat.ucrReceiverSingle()
+        Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrChkweights = New instat.ucrCheck()
         Me.grpSort.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'ucrSelectorOneWayFreq
-        '
-        Me.ucrSelectorOneWayFreq.bShowHiddenColumns = False
-        Me.ucrSelectorOneWayFreq.bUseCurrentFilter = True
-        Me.ucrSelectorOneWayFreq.Location = New System.Drawing.Point(10, 10)
-        Me.ucrSelectorOneWayFreq.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrSelectorOneWayFreq.Name = "ucrSelectorOneWayFreq"
-        Me.ucrSelectorOneWayFreq.Size = New System.Drawing.Size(210, 180)
-        Me.ucrSelectorOneWayFreq.TabIndex = 0
-        '
-        'ucrReceiverOneWayFreq
-        '
-        Me.ucrReceiverOneWayFreq.frmParent = Me
-        Me.ucrReceiverOneWayFreq.Location = New System.Drawing.Point(295, 60)
-        Me.ucrReceiverOneWayFreq.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverOneWayFreq.Name = "ucrReceiverOneWayFreq"
-        Me.ucrReceiverOneWayFreq.Selector = Nothing
-        Me.ucrReceiverOneWayFreq.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverOneWayFreq.TabIndex = 1
-        '
-        'ucrSaveGraph
-        '
-        Me.ucrSaveGraph.Location = New System.Drawing.Point(9, 265)
-        Me.ucrSaveGraph.Name = "ucrSaveGraph"
-        Me.ucrSaveGraph.Size = New System.Drawing.Size(294, 24)
-        Me.ucrSaveGraph.TabIndex = 5
-        '
-        'ucrBase
-        '
-        Me.ucrBase.Location = New System.Drawing.Point(9, 293)
-        Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
-        Me.ucrBase.TabIndex = 6
-        '
-        'ucrChkTable
-        '
-        Me.ucrChkTable.Checked = False
-        Me.ucrChkTable.Location = New System.Drawing.Point(10, 239)
-        Me.ucrChkTable.Name = "ucrChkTable"
-        Me.ucrChkTable.Size = New System.Drawing.Size(145, 20)
-        Me.ucrChkTable.TabIndex = 10
-        '
-        'ucrChkweights
-        '
-        Me.ucrChkweights.Checked = False
-        Me.ucrChkweights.Location = New System.Drawing.Point(10, 204)
-        Me.ucrChkweights.Name = "ucrChkweights"
-        Me.ucrChkweights.Size = New System.Drawing.Size(145, 20)
-        Me.ucrChkweights.TabIndex = 11
-        '
-        'ucrChkGraph
-        '
-        Me.ucrChkGraph.Checked = False
-        Me.ucrChkGraph.Location = New System.Drawing.Point(158, 239)
-        Me.ucrChkGraph.Name = "ucrChkGraph"
-        Me.ucrChkGraph.Size = New System.Drawing.Size(145, 20)
-        Me.ucrChkGraph.TabIndex = 12
         '
         'grpSort
         '
@@ -104,7 +46,7 @@ Partial Class dlgOneWayFrequencies
         Me.grpSort.Controls.Add(Me.rdoAscending)
         Me.grpSort.Controls.Add(Me.rdoNone)
         Me.grpSort.Controls.Add(Me.ucrPnlSort)
-        Me.grpSort.Location = New System.Drawing.Point(295, 99)
+        Me.grpSort.Location = New System.Drawing.Point(267, 114)
         Me.grpSort.Name = "grpSort"
         Me.grpSort.Size = New System.Drawing.Size(123, 91)
         Me.grpSort.TabIndex = 14
@@ -153,7 +95,7 @@ Partial Class dlgOneWayFrequencies
         '
         'cmdOptions
         '
-        Me.cmdOptions.Location = New System.Drawing.Point(318, 204)
+        Me.cmdOptions.Location = New System.Drawing.Point(280, 216)
         Me.cmdOptions.Name = "cmdOptions"
         Me.cmdOptions.Size = New System.Drawing.Size(69, 23)
         Me.cmdOptions.TabIndex = 15
@@ -163,7 +105,7 @@ Partial Class dlgOneWayFrequencies
         'lblSelectedVariable
         '
         Me.lblSelectedVariable.AutoSize = True
-        Me.lblSelectedVariable.Location = New System.Drawing.Point(292, 41)
+        Me.lblSelectedVariable.Location = New System.Drawing.Point(267, 61)
         Me.lblSelectedVariable.Name = "lblSelectedVariable"
         Me.lblSelectedVariable.Size = New System.Drawing.Size(93, 13)
         Me.lblSelectedVariable.TabIndex = 16
@@ -172,22 +114,80 @@ Partial Class dlgOneWayFrequencies
         'ucrChkFlip
         '
         Me.ucrChkFlip.Checked = False
-        Me.ucrChkFlip.Location = New System.Drawing.Point(158, 204)
+        Me.ucrChkFlip.Location = New System.Drawing.Point(10, 202)
         Me.ucrChkFlip.Name = "ucrChkFlip"
         Me.ucrChkFlip.Size = New System.Drawing.Size(145, 20)
         Me.ucrChkFlip.TabIndex = 17
+        '
+        'ucrChkGraph
+        '
+        Me.ucrChkGraph.Checked = False
+        Me.ucrChkGraph.Location = New System.Drawing.Point(9, 252)
+        Me.ucrChkGraph.Name = "ucrChkGraph"
+        Me.ucrChkGraph.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkGraph.TabIndex = 12
+        '
+        'ucrChkTable
+        '
+        Me.ucrChkTable.Checked = False
+        Me.ucrChkTable.Location = New System.Drawing.Point(10, 227)
+        Me.ucrChkTable.Name = "ucrChkTable"
+        Me.ucrChkTable.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkTable.TabIndex = 10
+        '
+        'ucrBase
+        '
+        Me.ucrBase.Location = New System.Drawing.Point(9, 302)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 6
+        '
+        'ucrSaveGraph
+        '
+        Me.ucrSaveGraph.Location = New System.Drawing.Point(9, 277)
+        Me.ucrSaveGraph.Name = "ucrSaveGraph"
+        Me.ucrSaveGraph.Size = New System.Drawing.Size(294, 24)
+        Me.ucrSaveGraph.TabIndex = 5
+        '
+        'ucrReceiverOneWayFreq
+        '
+        Me.ucrReceiverOneWayFreq.frmParent = Me
+        Me.ucrReceiverOneWayFreq.Location = New System.Drawing.Point(270, 77)
+        Me.ucrReceiverOneWayFreq.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverOneWayFreq.Name = "ucrReceiverOneWayFreq"
+        Me.ucrReceiverOneWayFreq.Selector = Nothing
+        Me.ucrReceiverOneWayFreq.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverOneWayFreq.TabIndex = 1
+        '
+        'ucrSelectorOneWayFreq
+        '
+        Me.ucrSelectorOneWayFreq.bShowHiddenColumns = False
+        Me.ucrSelectorOneWayFreq.bUseCurrentFilter = True
+        Me.ucrSelectorOneWayFreq.Location = New System.Drawing.Point(10, 10)
+        Me.ucrSelectorOneWayFreq.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorOneWayFreq.Name = "ucrSelectorOneWayFreq"
+        Me.ucrSelectorOneWayFreq.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorOneWayFreq.TabIndex = 0
+        '
+        'ucrChkweights
+        '
+        Me.ucrChkweights.Checked = False
+        Me.ucrChkweights.Location = New System.Drawing.Point(270, 27)
+        Me.ucrChkweights.Name = "ucrChkweights"
+        Me.ucrChkweights.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkweights.TabIndex = 18
         '
         'dlgOneWayFrequencies
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(440, 353)
+        Me.ClientSize = New System.Drawing.Size(427, 361)
+        Me.Controls.Add(Me.ucrChkweights)
         Me.Controls.Add(Me.ucrChkFlip)
         Me.Controls.Add(Me.lblSelectedVariable)
         Me.Controls.Add(Me.cmdOptions)
         Me.Controls.Add(Me.grpSort)
         Me.Controls.Add(Me.ucrChkGraph)
-        Me.Controls.Add(Me.ucrChkweights)
         Me.Controls.Add(Me.ucrChkTable)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrSaveGraph)
@@ -211,7 +211,6 @@ Partial Class dlgOneWayFrequencies
     Friend WithEvents ucrSaveGraph As ucrSave
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrChkGraph As ucrCheck
-    Friend WithEvents ucrChkweights As ucrCheck
     Friend WithEvents ucrChkTable As ucrCheck
     Friend WithEvents grpSort As GroupBox
     Friend WithEvents rdoDescending As RadioButton
@@ -221,4 +220,5 @@ Partial Class dlgOneWayFrequencies
     Friend WithEvents cmdOptions As Button
     Friend WithEvents lblSelectedVariable As Label
     Friend WithEvents ucrChkFlip As ucrCheck
+    Friend WithEvents ucrChkweights As ucrCheck
 End Class

--- a/instat/dlgOneWayFrequencies.Designer.vb
+++ b/instat/dlgOneWayFrequencies.Designer.vb
@@ -1,0 +1,224 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class dlgOneWayFrequencies
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.ucrSelectorOneWayFreq = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrReceiverOneWayFreq = New instat.ucrReceiverSingle()
+        Me.ucrSaveGraph = New instat.ucrSave()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrChkTable = New instat.ucrCheck()
+        Me.ucrChkweights = New instat.ucrCheck()
+        Me.ucrChkGraph = New instat.ucrCheck()
+        Me.grpSort = New System.Windows.Forms.GroupBox()
+        Me.rdoDescending = New System.Windows.Forms.RadioButton()
+        Me.rdoAscending = New System.Windows.Forms.RadioButton()
+        Me.rdoNone = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlSort = New instat.UcrPanel()
+        Me.cmdOptions = New System.Windows.Forms.Button()
+        Me.lblSelectedVariable = New System.Windows.Forms.Label()
+        Me.ucrChkFlip = New instat.ucrCheck()
+        Me.grpSort.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'ucrSelectorOneWayFreq
+        '
+        Me.ucrSelectorOneWayFreq.bShowHiddenColumns = False
+        Me.ucrSelectorOneWayFreq.bUseCurrentFilter = True
+        Me.ucrSelectorOneWayFreq.Location = New System.Drawing.Point(10, 10)
+        Me.ucrSelectorOneWayFreq.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorOneWayFreq.Name = "ucrSelectorOneWayFreq"
+        Me.ucrSelectorOneWayFreq.Size = New System.Drawing.Size(210, 180)
+        Me.ucrSelectorOneWayFreq.TabIndex = 0
+        '
+        'ucrReceiverOneWayFreq
+        '
+        Me.ucrReceiverOneWayFreq.frmParent = Me
+        Me.ucrReceiverOneWayFreq.Location = New System.Drawing.Point(295, 60)
+        Me.ucrReceiverOneWayFreq.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverOneWayFreq.Name = "ucrReceiverOneWayFreq"
+        Me.ucrReceiverOneWayFreq.Selector = Nothing
+        Me.ucrReceiverOneWayFreq.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverOneWayFreq.TabIndex = 1
+        '
+        'ucrSaveGraph
+        '
+        Me.ucrSaveGraph.Location = New System.Drawing.Point(9, 265)
+        Me.ucrSaveGraph.Name = "ucrSaveGraph"
+        Me.ucrSaveGraph.Size = New System.Drawing.Size(294, 24)
+        Me.ucrSaveGraph.TabIndex = 5
+        '
+        'ucrBase
+        '
+        Me.ucrBase.Location = New System.Drawing.Point(9, 293)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(410, 52)
+        Me.ucrBase.TabIndex = 6
+        '
+        'ucrChkTable
+        '
+        Me.ucrChkTable.Checked = False
+        Me.ucrChkTable.Location = New System.Drawing.Point(10, 239)
+        Me.ucrChkTable.Name = "ucrChkTable"
+        Me.ucrChkTable.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkTable.TabIndex = 10
+        '
+        'ucrChkweights
+        '
+        Me.ucrChkweights.Checked = False
+        Me.ucrChkweights.Location = New System.Drawing.Point(10, 204)
+        Me.ucrChkweights.Name = "ucrChkweights"
+        Me.ucrChkweights.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkweights.TabIndex = 11
+        '
+        'ucrChkGraph
+        '
+        Me.ucrChkGraph.Checked = False
+        Me.ucrChkGraph.Location = New System.Drawing.Point(158, 239)
+        Me.ucrChkGraph.Name = "ucrChkGraph"
+        Me.ucrChkGraph.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkGraph.TabIndex = 12
+        '
+        'grpSort
+        '
+        Me.grpSort.Controls.Add(Me.rdoDescending)
+        Me.grpSort.Controls.Add(Me.rdoAscending)
+        Me.grpSort.Controls.Add(Me.rdoNone)
+        Me.grpSort.Controls.Add(Me.ucrPnlSort)
+        Me.grpSort.Location = New System.Drawing.Point(295, 99)
+        Me.grpSort.Name = "grpSort"
+        Me.grpSort.Size = New System.Drawing.Size(123, 91)
+        Me.grpSort.TabIndex = 14
+        Me.grpSort.TabStop = False
+        Me.grpSort.Text = "Sort"
+        '
+        'rdoDescending
+        '
+        Me.rdoDescending.AutoSize = True
+        Me.rdoDescending.Location = New System.Drawing.Point(10, 65)
+        Me.rdoDescending.Name = "rdoDescending"
+        Me.rdoDescending.Size = New System.Drawing.Size(82, 17)
+        Me.rdoDescending.TabIndex = 3
+        Me.rdoDescending.TabStop = True
+        Me.rdoDescending.Text = "Descending"
+        Me.rdoDescending.UseVisualStyleBackColor = True
+        '
+        'rdoAscending
+        '
+        Me.rdoAscending.AutoSize = True
+        Me.rdoAscending.Location = New System.Drawing.Point(10, 43)
+        Me.rdoAscending.Name = "rdoAscending"
+        Me.rdoAscending.Size = New System.Drawing.Size(75, 17)
+        Me.rdoAscending.TabIndex = 2
+        Me.rdoAscending.TabStop = True
+        Me.rdoAscending.Text = "Ascending"
+        Me.rdoAscending.UseVisualStyleBackColor = True
+        '
+        'rdoNone
+        '
+        Me.rdoNone.AutoSize = True
+        Me.rdoNone.Location = New System.Drawing.Point(10, 21)
+        Me.rdoNone.Name = "rdoNone"
+        Me.rdoNone.Size = New System.Drawing.Size(51, 17)
+        Me.rdoNone.TabIndex = 1
+        Me.rdoNone.TabStop = True
+        Me.rdoNone.Text = "None"
+        Me.rdoNone.UseVisualStyleBackColor = True
+        '
+        'ucrPnlSort
+        '
+        Me.ucrPnlSort.Location = New System.Drawing.Point(3, 16)
+        Me.ucrPnlSort.Name = "ucrPnlSort"
+        Me.ucrPnlSort.Size = New System.Drawing.Size(114, 69)
+        Me.ucrPnlSort.TabIndex = 0
+        '
+        'cmdOptions
+        '
+        Me.cmdOptions.Location = New System.Drawing.Point(318, 204)
+        Me.cmdOptions.Name = "cmdOptions"
+        Me.cmdOptions.Size = New System.Drawing.Size(69, 23)
+        Me.cmdOptions.TabIndex = 15
+        Me.cmdOptions.Text = " Options"
+        Me.cmdOptions.UseVisualStyleBackColor = True
+        '
+        'lblSelectedVariable
+        '
+        Me.lblSelectedVariable.AutoSize = True
+        Me.lblSelectedVariable.Location = New System.Drawing.Point(292, 41)
+        Me.lblSelectedVariable.Name = "lblSelectedVariable"
+        Me.lblSelectedVariable.Size = New System.Drawing.Size(93, 13)
+        Me.lblSelectedVariable.TabIndex = 16
+        Me.lblSelectedVariable.Text = "Selected Variable:"
+        '
+        'ucrChkFlip
+        '
+        Me.ucrChkFlip.Checked = False
+        Me.ucrChkFlip.Location = New System.Drawing.Point(158, 204)
+        Me.ucrChkFlip.Name = "ucrChkFlip"
+        Me.ucrChkFlip.Size = New System.Drawing.Size(145, 20)
+        Me.ucrChkFlip.TabIndex = 17
+        '
+        'dlgOneWayFrequencies
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(440, 353)
+        Me.Controls.Add(Me.ucrChkFlip)
+        Me.Controls.Add(Me.lblSelectedVariable)
+        Me.Controls.Add(Me.cmdOptions)
+        Me.Controls.Add(Me.grpSort)
+        Me.Controls.Add(Me.ucrChkGraph)
+        Me.Controls.Add(Me.ucrChkweights)
+        Me.Controls.Add(Me.ucrChkTable)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.ucrSaveGraph)
+        Me.Controls.Add(Me.ucrReceiverOneWayFreq)
+        Me.Controls.Add(Me.ucrSelectorOneWayFreq)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "dlgOneWayFrequencies"
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
+        Me.Text = "One Way Frequencies"
+        Me.grpSort.ResumeLayout(False)
+        Me.grpSort.PerformLayout()
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ucrSelectorOneWayFreq As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrReceiverOneWayFreq As ucrReceiverSingle
+    Friend WithEvents ucrSaveGraph As ucrSave
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrChkGraph As ucrCheck
+    Friend WithEvents ucrChkweights As ucrCheck
+    Friend WithEvents ucrChkTable As ucrCheck
+    Friend WithEvents grpSort As GroupBox
+    Friend WithEvents rdoDescending As RadioButton
+    Friend WithEvents rdoAscending As RadioButton
+    Friend WithEvents rdoNone As RadioButton
+    Friend WithEvents ucrPnlSort As UcrPanel
+    Friend WithEvents cmdOptions As Button
+    Friend WithEvents lblSelectedVariable As Label
+    Friend WithEvents ucrChkFlip As ucrCheck
+End Class

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -1,0 +1,73 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat.Translations
+
+Public Class dlgOneWayFrequencies
+    Private bFirstLoad As Boolean = True
+    Private bReset As Boolean = True
+    Private bResetSubdialog As Boolean = False
+    Private Sub dlgOneWayFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        autoTranslate(Me)
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRCodeForControls(bReset)
+        bReset = False
+    End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+        SetRCode(Me, ucrBase.clsRsyntax.clsBaseFunction, bReset)
+    End Sub
+
+    Private Sub InitialiseDialog()
+        ucrReceiverOneWayFreq.Selector = ucrSelectorOneWayFreq
+        ucrReceiverOneWayFreq.SetMeAsReceiver()
+        ucrReceiverOneWayFreq.SetParameter(New RParameter("", 1))
+        ucrReceiverOneWayFreq.SetParameterIsString()
+
+
+        ucrChkTable.SetText("Table")
+        ucrChkweights.SetText("Weights")
+        ucrChkGraph.SetText("Graph")
+        ucrChkFlip.SetText("Flip Coordinates")
+
+        ucrSaveGraph.SetPrefix("one_way_freq")
+        ucrSaveGraph.SetSaveTypeAsGraph()
+        ucrSaveGraph.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
+        ucrSaveGraph.SetCheckBoxText("Save Graph")
+        ucrSaveGraph.SetIsComboBox()
+        ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
+    End Sub
+
+    Private Sub SetDefaults()
+        ucrSelectorOneWayFreq.Reset()
+        ucrSaveGraph.Reset()
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged
+        TestOkEnabled()
+    End Sub
+
+End Class

--- a/instat/dlgOneWayFrequencies.vb
+++ b/instat/dlgOneWayFrequencies.vb
@@ -20,6 +20,8 @@ Public Class dlgOneWayFrequencies
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private bResetSubdialog As Boolean = False
+    Private clsSjtFreq As New RFunction
+    Private clsSjpFrq As New RFunction
     Private Sub dlgOneWayFrequencies_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
         If bFirstLoad Then
@@ -34,36 +36,97 @@ Public Class dlgOneWayFrequencies
     End Sub
 
     Public Sub SetRCodeForControls(bReset As Boolean)
-        SetRCode(Me, ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrReceiverOneWayFreq.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrPnlSort.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrChkTable.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+        ucrChkGraph.SetRCode(ucrBase.clsRsyntax.clsBaseFunction, bReset)
+
     End Sub
 
     Private Sub InitialiseDialog()
+        'HelpID
+        ' ucrBase.iHelpTopicID = 
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
+        ucrBase.clsRsyntax.iCallType = 3
+
         ucrReceiverOneWayFreq.Selector = ucrSelectorOneWayFreq
         ucrReceiverOneWayFreq.SetMeAsReceiver()
-        ucrReceiverOneWayFreq.SetParameter(New RParameter("", 1))
-        ucrReceiverOneWayFreq.SetParameterIsString()
+        ucrReceiverOneWayFreq.SetParameter(New RParameter("data", 1))
+        ucrReceiverOneWayFreq.SetParameterIsRFunction()
+
+
+        ucrPnlSort.SetParameter(New RParameter("sort.frq"))
+        ucrPnlSort.AddRadioButton(rdoNone, Chr(34) & "none" & Chr(34))
+        ucrPnlSort.AddRadioButton(rdoAscending, Chr(34) & "asc" & Chr(34))
+        ucrPnlSort.AddRadioButton(rdoDescending, Chr(34) & "desc" & Chr(34))
+        ucrPnlSort.SetRDefault(Chr(34) & "none" & Chr(34))
 
 
         ucrChkTable.SetText("Table")
         ucrChkweights.SetText("Weights")
         ucrChkGraph.SetText("Graph")
+        ' ucrChkGraph.SetParameter(New RParameter("type"))
+
         ucrChkFlip.SetText("Flip Coordinates")
+        ucrChkFlip.SetParameter(New RParameter("coord.flip"), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
+        ucrChkFlip.SetRDefault("FALSE")
 
         ucrSaveGraph.SetPrefix("one_way_freq")
         ucrSaveGraph.SetSaveTypeAsGraph()
         ucrSaveGraph.SetDataFrameSelector(ucrSelectorOneWayFreq.ucrAvailableDataFrames)
         ucrSaveGraph.SetCheckBoxText("Save Graph")
         ucrSaveGraph.SetIsComboBox()
-        ucrSaveGraph.SetAssignToIfUncheckedValue("last_graph")
     End Sub
 
     Private Sub SetDefaults()
+        clsSjtFreq = New RFunction
+        clsSjpFrq = New RFunction
         ucrSelectorOneWayFreq.Reset()
         ucrSaveGraph.Reset()
+        ucrReceiverOneWayFreq.SetParameter(New RParameter("data", 1))
+        ucrReceiverOneWayFreq.SetParameterIsRFunction()
+        clsSjtFreq.SetRCommand("sjPlot::sjt.frq")
+        clsSjtFreq.AddParameter("data", clsRFunctionParameter:=ucrReceiverOneWayFreq.GetVariables)
+        clsSjtFreq.AddParameter("sort.frq", Chr(34) & "none" & Chr(34))
+        clsSjtFreq.AddParameter("use.viewer", "FALSE")
+        clsSjpFrq.SetRCommand("sjPlot::sjp.frq")
+        clsSjpFrq.AddParameter("var.cnt", clsRFunctionParameter:=ucrReceiverOneWayFreq.GetVariables)
+
+        ucrBase.clsRsyntax.SetBaseRFunction(clsSjtFreq)
     End Sub
 
     Private Sub TestOkEnabled()
+        If Not ucrReceiverOneWayFreq.IsEmpty() AndAlso ucrSaveGraph.IsComplete() Then
+            ucrBase.OKEnabled(True)
+        Else
+            ucrBase.OKEnabled(False)
+        End If
+    End Sub
 
+    Private Sub ChangeBaseFunction()
+        If ucrChkTable.Checked Then
+            ucrReceiverOneWayFreq.SetParameter(New RParameter("data", 1))
+            ucrReceiverOneWayFreq.SetParameterIsRFunction()
+            ucrBase.clsRsyntax.SetBaseRFunction(clsSjtFreq)
+        Else
+            ucrReceiverOneWayFreq.SetParameter(New RParameter("var.cnt", 1))
+            ucrReceiverOneWayFreq.SetParameterIsRFunction()
+            ucrBase.clsRsyntax.SetBaseRFunction(clsSjpFrq)
+        End If
+        SetRCodeForControls(False)
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub AllControls_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneWayFreq.ControlValueChanged, ucrChkTable.ControlValueChanged, ucrChkGraph.ControlValueChanged, ucrPnlSort.ControlValueChanged
+        If ucrChkweights.Checked Then
+            ucrReceiverOneWayFreq.SetDataType("numeric")
+        End If
+        ChangeBaseFunction()
     End Sub
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverOneWayFreq.ControlContentsChanged, ucrSaveGraph.ControlContentsChanged

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -27,6 +27,8 @@ Partial Class frmMain
         Me.mnuDescribeOneVariable = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeOneVariableSummarise = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeOneVariableGraph = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator33 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuDescribeOneVariableFrequencies = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeTwoVariables = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeTwoVariablesSummarise = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuDescribeTwoVariablesTabulate = New System.Windows.Forms.ToolStripMenuItem()
@@ -447,13 +449,13 @@ Partial Class frmMain
         '
         Me.mnuDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariable, Me.mnuDescribeTwoVariables, Me.mnuDescribeSpecific, Me.mnuDescribeGeneral, Me.ToolStripSeparator9, Me.mnuDescribeMultivariate, Me.mnuDescribeMoreGraphs, Me.ToolStripSeparator13, Me.mnuDescribeUseGraph, Me.mnuDescribeCombineGraph, Me.mnuDescribeThemes})
         Me.mnuDescribe.Name = "mnuDescribe"
-        Me.mnuDescribe.Size = New System.Drawing.Size(64, 19)
+        Me.mnuDescribe.Size = New System.Drawing.Size(64, 20)
         Me.mnuDescribe.Tag = "Describe"
         Me.mnuDescribe.Text = "Describe"
         '
         'mnuDescribeOneVariable
         '
-        Me.mnuDescribeOneVariable.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariableSummarise, Me.mnuDescribeOneVariableGraph})
+        Me.mnuDescribeOneVariable.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariableSummarise, Me.mnuDescribeOneVariableGraph, Me.ToolStripSeparator33, Me.mnuDescribeOneVariableFrequencies})
         Me.mnuDescribeOneVariable.Name = "mnuDescribeOneVariable"
         Me.mnuDescribeOneVariable.Size = New System.Drawing.Size(172, 22)
         Me.mnuDescribeOneVariable.Tag = "One_Variable"
@@ -462,16 +464,27 @@ Partial Class frmMain
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(142, 22)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(152, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         '
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(142, 22)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(152, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
+        '
+        'ToolStripSeparator33
+        '
+        Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(149, 6)
+        '
+        'mnuDescribeOneVariableFrequencies
+        '
+        Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(152, 22)
+        Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies"
         '
         'mnuDescribeTwoVariables
         '
@@ -720,7 +733,7 @@ Partial Class frmMain
         '
         Me.mnuModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelProbabilityDistributions, Me.ToolStripSeparator3, Me.mnuModelOneVariable, Me.mnuModelTwoVariables, Me.mnuModelThreeVariables, Me.mnuModelFourVariables, Me.mnuModelGeneral, Me.ToolStripSeparator4, Me.mnuModelOtherOneVariable, Me.mnuModelOtherTwoVariables, Me.mnuModelOtherThreeVariables, Me.mnuModelOtherGeneral})
         Me.mnuModel.Name = "mnuModel"
-        Me.mnuModel.Size = New System.Drawing.Size(53, 19)
+        Me.mnuModel.Size = New System.Drawing.Size(53, 20)
         Me.mnuModel.Tag = "Model"
         Me.mnuModel.Text = "Model"
         '
@@ -1150,7 +1163,7 @@ Partial Class frmMain
         '
         Me.mnuView.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuViewDataView, Me.mnuViewOutputWindow, Me.mnuViewLog, Me.mnuViewScriptWindow, Me.mnuViewColumnMetadata, Me.mnuViewDataFrameMetadata, Me.ToolStripSeparator22, Me.mnuViewCascade, Me.mnuViewTileVertically, Me.mnuViewTileHorizontally})
         Me.mnuView.Name = "mnuView"
-        Me.mnuView.Size = New System.Drawing.Size(44, 19)
+        Me.mnuView.Size = New System.Drawing.Size(44, 20)
         Me.mnuView.Tag = "View"
         Me.mnuView.Text = "View"
         '
@@ -1222,7 +1235,7 @@ Partial Class frmMain
         '
         Me.mnuHelp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelpHelpIntroduction, Me.mnuHelpHistFAQ, Me.mnuHelpSpreadsheet, Me.mnuHelpGetingStarted, Me.ToolStripSeparator28, Me.mnuHelpMenus, Me.mnuHelpR, Me.mnuHelpRPackagesCommands, Me.mnuHelpDataset, Me.ToolStripSeparator29, Me.mnuHelpGuide, Me.mnuHelpAboutRInstat, Me.mnuHelpLicence})
         Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(44, 19)
+        Me.mnuHelp.Size = New System.Drawing.Size(44, 20)
         Me.mnuHelp.Tag = "Help"
         Me.mnuHelp.Text = "Help"
         '
@@ -1334,7 +1347,7 @@ Partial Class frmMain
         '
         Me.mnuClimatic.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticFile, Me.ToolStripSeparator18, Me.mnuCliDefineClimaticData, Me.mnuClimaticPrepare, Me.mnuClimaticQualityControl, Me.ToolStripSeparator30, Me.mnuClimdex, Me.mnuClimaticDescribe, Me.mnuClimaticPICSA, Me.ToolStripSeparator16, Me.mnuClimaticModels, Me.mnuClimaticExamine, Me.mnuClimaticProcess, Me.ToolStripSeparator23, Me.mnuClimaticSCF, Me.mnuClimaticEvaporation, Me.mnuClimaticCrop, Me.mnuClimaticHeatSum, Me.mnuClimateMethods})
         Me.mnuClimatic.Name = "mnuClimatic"
-        Me.mnuClimatic.Size = New System.Drawing.Size(63, 19)
+        Me.mnuClimatic.Size = New System.Drawing.Size(63, 20)
         Me.mnuClimatic.Tag = "Climatic"
         Me.mnuClimatic.Text = "Climatic"
         '
@@ -2148,7 +2161,7 @@ Partial Class frmMain
         '
         Me.mnuEdit.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuEditFind, Me.mnuEditFindNext, Me.mnuEditReplace, Me.mnuEditCut, Me.mnuEditCopy, Me.mnuEditCopySpecial, Me.mnuEditPaste, Me.mnuEditSelectAll})
         Me.mnuEdit.Name = "mnuEdit"
-        Me.mnuEdit.Size = New System.Drawing.Size(39, 19)
+        Me.mnuEdit.Size = New System.Drawing.Size(39, 20)
         Me.mnuEdit.Tag = "Edit"
         Me.mnuEdit.Text = "Edit"
         '
@@ -2222,11 +2235,10 @@ Partial Class frmMain
         'stsStrip
         '
         Me.stsStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.tstatus})
-        Me.stsStrip.Location = New System.Drawing.Point(0, 851)
+        Me.stsStrip.Location = New System.Drawing.Point(0, 285)
         Me.stsStrip.Name = "stsStrip"
-        Me.stsStrip.Padding = New System.Windows.Forms.Padding(3, 0, 37, 0)
         Me.stsStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
-        Me.stsStrip.Size = New System.Drawing.Size(1596, 22)
+        Me.stsStrip.Size = New System.Drawing.Size(508, 22)
         Me.stsStrip.TabIndex = 8
         Me.stsStrip.Text = "Status"
         '
@@ -2240,11 +2252,10 @@ Partial Class frmMain
         '
         Me.Tool_strip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden
         Me.Tool_strip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTbNew, Me.mnuTbOpen, Me.mnuTbSave, Me.mnuTbPrint, Me.toolStripSeparator, Me.mnuTbCut, Me.mnuTbCopy, Me.mnuTbPaste, Me.mnuTbDelete, Me.separator1, Me.EditLastDialogueToolStrip, Me.mnuTbShowLast10, Me.separator2, Me.mnuTbHelp})
-        Me.Tool_strip.Location = New System.Drawing.Point(0, 29)
+        Me.Tool_strip.Location = New System.Drawing.Point(0, 24)
         Me.Tool_strip.Name = "Tool_strip"
-        Me.Tool_strip.Padding = New System.Windows.Forms.Padding(0, 0, 3, 0)
         Me.Tool_strip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
-        Me.Tool_strip.Size = New System.Drawing.Size(1596, 25)
+        Me.Tool_strip.Size = New System.Drawing.Size(508, 25)
         Me.Tool_strip.TabIndex = 7
         Me.Tool_strip.Text = "Tool"
         '
@@ -2386,10 +2397,9 @@ Partial Class frmMain
         Me.mnuBar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow
         Me.mnuBar.Location = New System.Drawing.Point(0, 0)
         Me.mnuBar.Name = "mnuBar"
-        Me.mnuBar.Padding = New System.Windows.Forms.Padding(16, 5, 0, 5)
         Me.mnuBar.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
         Me.mnuBar.ShowItemToolTips = True
-        Me.mnuBar.Size = New System.Drawing.Size(1596, 29)
+        Me.mnuBar.Size = New System.Drawing.Size(508, 24)
         Me.mnuBar.TabIndex = 6
         Me.mnuBar.Text = "Menu_strip"
         '
@@ -2397,7 +2407,7 @@ Partial Class frmMain
         '
         Me.mnuFile.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileNewDataFrame, Me.mnuFileOpenFromFile, Me.mnuFileOpenFromLibrary, Me.mnuImportFromODK, Me.ToolStripSeparator27, Me.mnuFileConvert, Me.tlSeparatorFile, Me.mnuFileSave, Me.mnuFileSaveAs, Me.mnuExport, Me.mnuFilePrint, Me.mnuFilePrintPreview, Me.tlSeparatorFile3, Me.mnuFileCloseData, Me.ToolStripSeparator8, Me.mnuFIleExit})
         Me.mnuFile.Name = "mnuFile"
-        Me.mnuFile.Size = New System.Drawing.Size(37, 19)
+        Me.mnuFile.Size = New System.Drawing.Size(37, 20)
         Me.mnuFile.Tag = "File"
         Me.mnuFile.Text = "File"
         '
@@ -2468,7 +2478,7 @@ Partial Class frmMain
         '
         Me.mnuPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrame, Me.mnuPrepareCheckData, Me.ToolStripSeparator6, Me.mnuPrepareColumnCalculate, Me.mnuPrepareColumnGenerate, Me.mnuPrepareColumnFactor, Me.mnuPrepareColumnText, Me.mnuPrepareColumnDate, Me.mnuPrepareColumnReshape, Me.ToolStripSeparator7, Me.mnuPrepareKeysAndLinks, Me.mnuPrepareDataObject, Me.mnuPrepareRObjects})
         Me.mnuPrepare.Name = "mnuPrepare"
-        Me.mnuPrepare.Size = New System.Drawing.Size(59, 19)
+        Me.mnuPrepare.Size = New System.Drawing.Size(59, 20)
         Me.mnuPrepare.Tag = "Prepare"
         Me.mnuPrepare.Text = "Prepare"
         '
@@ -3190,7 +3200,7 @@ Partial Class frmMain
         '
         Me.mnuCorruption.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuCorruptionFile, Me.mnuCorruptionDefineCorruptionData, Me.mnuCorruptionPrepare, Me.mnuCorruptionDescribe, Me.mnuCorruptionModel, Me.DefineRedFlagsToolStripMenuItem, Me.CalculateCRIToolStripMenuItem, Me.TestsAndChecksToolStripMenuItem})
         Me.mnuCorruption.Name = "mnuCorruption"
-        Me.mnuCorruption.Size = New System.Drawing.Size(77, 19)
+        Me.mnuCorruption.Size = New System.Drawing.Size(77, 20)
         Me.mnuCorruption.Text = "Corruption"
         '
         'mnuCorruptionFile
@@ -3302,7 +3312,7 @@ Partial Class frmMain
         '
         Me.mnuTools.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuToolsRunRCode, Me.mnuToolsRestartR, Me.mnuToolsCheckForUpdates, Me.mnuToolsClearOutputWindow, Me.ToolStripSeparator5, Me.mnuToolsSaveCurrentOptions, Me.mnuToolsLoadOptions, Me.mnuToolsOptions})
         Me.mnuTools.Name = "mnuTools"
-        Me.mnuTools.Size = New System.Drawing.Size(47, 19)
+        Me.mnuTools.Size = New System.Drawing.Size(47, 20)
         Me.mnuTools.Text = "Tools"
         '
         'mnuToolsRunRCode
@@ -3366,16 +3376,15 @@ Partial Class frmMain
         '
         'frmMain
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(16.0!, 31.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(1596, 873)
+        Me.ClientSize = New System.Drawing.Size(508, 307)
         Me.Controls.Add(Me.stsStrip)
         Me.Controls.Add(Me.Tool_strip)
         Me.Controls.Add(Me.mnuBar)
         Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
         Me.IsMdiContainer = True
         Me.MainMenuStrip = Me.mnuBar
-        Me.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
         Me.Name = "frmMain"
         Me.Text = "R-Instat"
         Me.WindowState = System.Windows.Forms.FormWindowState.Maximized
@@ -3804,4 +3813,6 @@ Partial Class frmMain
     Friend WithEvents AaToolStripMenuItem1 As ToolStripMenuItem
     Friend WithEvents CalculateCRIToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents TestsAndChecksToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator33 As ToolStripSeparator
+    Friend WithEvents mnuDescribeOneVariableFrequencies As ToolStripMenuItem
 End Class

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1166,6 +1166,10 @@ Public Class frmMain
         dlgRestrict.ShowDialog()
     End Sub
 
+    Private Sub mnuDescribeOneVariableFrequencies_Click(sender As Object, e As EventArgs) Handles mnuDescribeOneVariableFrequencies.Click
+        dlgOneWayFrequencies.ShowDialog()
+    End Sub
+
     'Private Sub TESTToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles TESTToolStripMenuItem.Click
     '    'TEST temporary 
     '    'TESTING TO BE ERASED !!!!!!!

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -359,6 +359,12 @@
     <Compile Include="dlgOneVarUseModel.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="dlgOneWayFrequencies.Designer.vb">
+      <DependentUpon>dlgOneWayFrequencies.vb</DependentUpon>
+    </Compile>
+    <Compile Include="dlgOneWayFrequencies.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="dlgOpenSST.Designer.vb">
       <DependentUpon>dlgOpenSST.vb</DependentUpon>
     </Compile>
@@ -2487,6 +2493,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="dlgOneWayANOVA.sw-KE.resx">
       <DependentUpon>dlgOneWayANOVA.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="dlgOneWayFrequencies.resx">
+      <DependentUpon>dlgOneWayFrequencies.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="dlgOpenSST.fr-FR.resx">
       <DependentUpon>dlgOpenSST.vb</DependentUpon>


### PR DESCRIPTION
In Progress...
Issue: In R studio, the output of `sjt.frq`  by default is given in the output window  but this can be redirected to HTML  by changing  `use.viewer`  parameter from default as `TRUE`  to `FALSE`.
`sjt.frq(efc$e42dep,use.viewer=FALSE)` -HTML
`sjt.frq(efc$e42dep,use.viewer=TRUE)`- Rstudio output window
@dannyparsons @stevekogo 
Now coming to R-instat I am having a challenge redirecting the output to the R-Instat output window for the case of tables.  The tables (output) are redirected to  HTML which I guess is not what is required. I have tried using iCallType 2 and adding the parameter  `use.viewer` to control this, but apparently this does not help. 

For the graphs - its displaying well on the output window. 
@rdstern , Is the Weights check box supposed to pass `weight.by` parameter ? Just to be sure. otherwise not fully setup but almost
