### PR TITLE
dlgDuplicateColumns

### DIFF
--- a/instat/dlgDuplicateColumns.Designer.vb
+++ b/instat/dlgDuplicateColumns.Designer.vb
@@ -93,7 +93,7 @@ Partial Class dlgDuplicateColumns
         Me.grpDuplicatedColumn.Controls.Add(Me.ucrPnlColPosition)
         Me.grpDuplicatedColumn.Location = New System.Drawing.Point(225, 80)
         Me.grpDuplicatedColumn.Name = "grpDuplicatedColumn"
-        Me.grpDuplicatedColumn.Size = New System.Drawing.Size(185, 110)
+        Me.grpDuplicatedColumn.Size = New System.Drawing.Size(183, 110)
         Me.grpDuplicatedColumn.TabIndex = 3
         Me.grpDuplicatedColumn.TabStop = False
         Me.grpDuplicatedColumn.Text = "Position of Duplicated Column"

--- a/instat/dlgDuplicateColumns.Designer.vb
+++ b/instat/dlgDuplicateColumns.Designer.vb
@@ -28,11 +28,11 @@ Partial Class dlgDuplicateColumns
         Me.ucrReceiverForCopyColumns = New instat.ucrReceiverSingle()
         Me.ucrSelectorForDuplicateColumn = New instat.ucrSelectorByDataFrameAddRemove()
         Me.grpDuplicatedColumn = New System.Windows.Forms.GroupBox()
-        Me.ucrPnlColPosition = New instat.UcrPanel()
         Me.rdoBefore = New System.Windows.Forms.RadioButton()
         Me.rdoEnd = New System.Windows.Forms.RadioButton()
         Me.rdoAfter = New System.Windows.Forms.RadioButton()
         Me.rdoBeginning = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlColPosition = New instat.UcrPanel()
         Me.ucrBase = New instat.ucrButtons()
         Me.grpDuplicatedColumn.SuspendLayout()
         Me.SuspendLayout()
@@ -40,7 +40,7 @@ Partial Class dlgDuplicateColumns
         'lblColumns
         '
         Me.lblColumns.AutoSize = True
-        Me.lblColumns.Location = New System.Drawing.Point(225, 37)
+        Me.lblColumns.Location = New System.Drawing.Point(225, 38)
         Me.lblColumns.Name = "lblColumns"
         Me.lblColumns.Size = New System.Drawing.Size(105, 13)
         Me.lblColumns.TabIndex = 1
@@ -49,7 +49,7 @@ Partial Class dlgDuplicateColumns
         'lblNewColumnName
         '
         Me.lblNewColumnName.AutoSize = True
-        Me.lblNewColumnName.Location = New System.Drawing.Point(9, 204)
+        Me.lblNewColumnName.Location = New System.Drawing.Point(10, 204)
         Me.lblNewColumnName.Name = "lblNewColumnName"
         Me.lblNewColumnName.Size = New System.Drawing.Size(101, 13)
         Me.lblNewColumnName.TabIndex = 4
@@ -57,6 +57,7 @@ Partial Class dlgDuplicateColumns
         '
         'ucrInputColumnName
         '
+        Me.ucrInputColumnName.AddQuotesIfUnrecognised = True
         Me.ucrInputColumnName.IsReadOnly = False
         Me.ucrInputColumnName.Location = New System.Drawing.Point(113, 201)
         Me.ucrInputColumnName.Name = "ucrInputColumnName"
@@ -70,7 +71,7 @@ Partial Class dlgDuplicateColumns
         Me.ucrReceiverForCopyColumns.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverForCopyColumns.Name = "ucrReceiverForCopyColumns"
         Me.ucrReceiverForCopyColumns.Selector = Nothing
-        Me.ucrReceiverForCopyColumns.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverForCopyColumns.Size = New System.Drawing.Size(129, 20)
         Me.ucrReceiverForCopyColumns.TabIndex = 2
         '
         'ucrSelectorForDuplicateColumn
@@ -96,13 +97,6 @@ Partial Class dlgDuplicateColumns
         Me.grpDuplicatedColumn.TabIndex = 3
         Me.grpDuplicatedColumn.TabStop = False
         Me.grpDuplicatedColumn.Text = "Position of Duplicated Column"
-        '
-        'ucrPnlColPosition
-        '
-        Me.ucrPnlColPosition.Location = New System.Drawing.Point(6, 19)
-        Me.ucrPnlColPosition.Name = "ucrPnlColPosition"
-        Me.ucrPnlColPosition.Size = New System.Drawing.Size(99, 85)
-        Me.ucrPnlColPosition.TabIndex = 7
         '
         'rdoBefore
         '
@@ -148,11 +142,18 @@ Partial Class dlgDuplicateColumns
         Me.rdoBeginning.Text = "Beginning"
         Me.rdoBeginning.UseVisualStyleBackColor = True
         '
+        'ucrPnlColPosition
+        '
+        Me.ucrPnlColPosition.Location = New System.Drawing.Point(6, 19)
+        Me.ucrPnlColPosition.Name = "ucrPnlColPosition"
+        Me.ucrPnlColPosition.Size = New System.Drawing.Size(99, 85)
+        Me.ucrPnlColPosition.TabIndex = 7
+        '
         'ucrBase
         '
         Me.ucrBase.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.ucrBase.Location = New System.Drawing.Point(12, 228)
+        Me.ucrBase.Location = New System.Drawing.Point(10, 228)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(398, 53)
         Me.ucrBase.TabIndex = 6

--- a/instat/dlgDuplicateColumns.vb
+++ b/instat/dlgDuplicateColumns.vb
@@ -71,13 +71,13 @@ Public Class dlgDuplicateColumns
         ucrInputColumnName.SetItemsTypeAsColumns()
         ucrInputColumnName.SetDefaultTypeAsColumn()
         ucrInputColumnName.SetValidationTypeAsRVariable()
-        ucrInputColumnName.bAllowNonConditionValues = True
     End Sub
 
     Private Sub SetDefaults()
         clsDefaultFunction = New RFunction
 
         ucrSelectorForDuplicateColumn.Reset()
+        ucrInputColumnName.bAllowNonConditionValues = True
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
         clsDefaultFunction.AddParameter("before", "FALSE")

--- a/instat/dlgDuplicateColumns.vb
+++ b/instat/dlgDuplicateColumns.vb
@@ -44,18 +44,18 @@ Public Class dlgDuplicateColumns
         ucrBase.iHelpTopicID = 512
 
         ' For ucrSelector
-        ucrSelectorForDuplicateColumn.SetParameter(New RParameter("data_name"))
+        ucrSelectorForDuplicateColumn.SetParameter(New RParameter("data_name", 0))
         ucrSelectorForDuplicateColumn.SetParameterIsString()
 
         ' For ucrReceiver
-        ucrReceiverForCopyColumns.SetParameter(New RParameter("col_data"))
+        ucrReceiverForCopyColumns.SetParameter(New RParameter("col_data", 1))
         ucrReceiverForCopyColumns.SetParameterIsRFunction()
         ucrReceiverForCopyColumns.Selector = ucrSelectorForDuplicateColumn
         ucrReceiverForCopyColumns.SetMeAsReceiver()
         ucrReceiverForCopyColumns.bUseFilteredData = False
 
         ' radio buttons
-        ucrPnlColPosition.SetParameter(New RParameter("before"))
+        ucrPnlColPosition.SetParameter(New RParameter("before", 3))
         ucrPnlColPosition.AddRadioButton(rdoBefore, "TRUE")
         ucrPnlColPosition.AddRadioButton(rdoAfter, "FALSE")
         ucrPnlColPosition.AddRadioButton(rdoBeginning, "TRUE")
@@ -66,7 +66,7 @@ Public Class dlgDuplicateColumns
         ucrPnlColPosition.AddParameterPresentCondition(rdoEnd, "adjacent_column", False)
 
         ' For ucrSaveColumn
-        ucrInputColumnName.SetParameter(New RParameter("col_name"))
+        ucrInputColumnName.SetParameter(New RParameter("col_name", 2))
         ucrInputColumnName.SetDataFrameSelector(ucrSelectorForDuplicateColumn.ucrAvailableDataFrames)
         ucrInputColumnName.SetItemsTypeAsColumns()
         ucrInputColumnName.SetDefaultTypeAsColumn()
@@ -78,6 +78,7 @@ Public Class dlgDuplicateColumns
 
         ucrSelectorForDuplicateColumn.Reset()
         ucrInputColumnName.bAllowNonConditionValues = True
+        ucrInputColumnName.Reset()
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
         clsDefaultFunction.AddParameter("before", "FALSE")
@@ -143,10 +144,14 @@ Public Class dlgDuplicateColumns
         PositionOfDuplicatedCols()
     End Sub
 
-    Private Sub ucrReceiverForCopyColumns_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverForCopyColumns.ControlValueChanged
-        If Not ucrInputColumnName.bUserTyped Then
+    Private Sub DefaultNewName()
+        If Not ucrInputColumnName.bUserTyped AndAlso Not ucrReceiverForCopyColumns.IsEmpty Then
             ucrInputColumnName.SetPrefix(ucrReceiverForCopyColumns.GetVariableNames(False))
         End If
+    End Sub
+
+    Private Sub ucrReceiverForCopyColumns_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverForCopyColumns.ControlValueChanged
+        DefaultNewName()
         PositionOfDuplicatedCols()
     End Sub
 End Class

--- a/instat/dlgDuplicateColumns.vb
+++ b/instat/dlgDuplicateColumns.vb
@@ -14,11 +14,11 @@
 ' You should have received a copy of the GNU General Public License k
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Imports instat
 Imports instat.Translations
 Public Class dlgDuplicateColumns
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
+    Private clsDefaultFunction As New RFunction
     Dim bUseSelectedColumn As Boolean = False
     Dim strSelectedColumn As String = ""
     Dim strSelectedDataFrame As String = ""
@@ -40,12 +40,6 @@ Public Class dlgDuplicateColumns
         SetRCode(Me, ucrBase.clsRsyntax.clsBaseFunction, bReset)
     End Sub
 
-
-    'Month <- InstatDataObject$get_columns_from_data(use_current_filter=FALSE,
-    ''''' 'col_name="Month", data_name="Damango")
-    'InstatDataObject$add_columns_to_data(col_data=UCRRECEIVERFORCOPYCOLUMNS, col_name="RECEIVERNAME1",
-    ''''' 'data_name="DATASET NAME", before=TRUE, adjacent_column )
-
     Private Sub InitialiseDialog()
         ucrBase.iHelpTopicID = 512
 
@@ -55,7 +49,7 @@ Public Class dlgDuplicateColumns
 
         ' For ucrReceiver
         ucrReceiverForCopyColumns.SetParameter(New RParameter("col_data"))
-        ucrReceiverForCopyColumns.SetParameterIsString()
+        ucrReceiverForCopyColumns.SetParameterIsRFunction()
         ucrReceiverForCopyColumns.Selector = ucrSelectorForDuplicateColumn
         ucrReceiverForCopyColumns.SetMeAsReceiver()
         ucrReceiverForCopyColumns.bUseFilteredData = False
@@ -74,20 +68,20 @@ Public Class dlgDuplicateColumns
         ' For ucrSaveColumn
         ucrInputColumnName.SetParameter(New RParameter("col_name"))
         ucrInputColumnName.SetDataFrameSelector(ucrSelectorForDuplicateColumn.ucrAvailableDataFrames)
-        ucrInputColumnName.SetPrefix(ucrReceiverForCopyColumns.GetVariableNames(False))
         ucrInputColumnName.SetItemsTypeAsColumns()
         ucrInputColumnName.SetDefaultTypeAsColumn()
         ucrInputColumnName.SetValidationTypeAsRVariable()
-
+        ucrInputColumnName.bAllowNonConditionValues = True
     End Sub
 
     Private Sub SetDefaults()
-        Dim clsDefaultFunction As New RFunction
+        clsDefaultFunction = New RFunction
 
         ucrSelectorForDuplicateColumn.Reset()
+
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
         clsDefaultFunction.AddParameter("before", "FALSE")
-        ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction.Clone())
+        ucrBase.clsRsyntax.SetBaseRFunction(clsDefaultFunction)
     End Sub
 
     Public Sub SetCurrentColumn(strColumn As String, strDataFrame As String)


### PR DESCRIPTION
@africanmathsinitiative/developers This is ready for review

Changes made:
- Bug fix. It was reading in the name of the column not the contents
- Updated some of the code in the SetDefaults sub
- Bug fix. ucrInputColumnName only has a name once something has been inputted in the receiver, so there was a developer error upon opening the dialog when nothing was in the receiver.