### PR TITLE
added user controls for all mdi child forms and implemented new window system in frmMain using split containers

### DIFF
--- a/instat/clsGridLink.vb
+++ b/instat/clsGridLink.vb
@@ -17,6 +17,7 @@ Imports RDotNet
 Imports unvell.ReoGrid
 
 Public Class clsGridLink
+    Public ucrDataViewer As ucrDataView
     Public grdData As ReoGridControl
     Public grdMetadata As ReoGridControl
     Public grdVariablesMetadata As ReoGridControl
@@ -104,7 +105,7 @@ Public Class clsGridLink
                     Else
                         FillSheet(dfTemp, strDataName, grdData, bInstatObjectDataFrame:=True, bIncludeDataTypes:=True, iNewPosition:=i, bFilterApplied:=False, bCheckFreezeColumns:=True)
                     End If
-                    frmEditor.SetColumnNames(strDataName, dfTemp.ColumnNames())
+                    ucrDataViewer.SetColumnNames(strDataName, dfTemp.ColumnNames())
                     clsSetDataFramesChanged.AddParameter("data_name", Chr(34) & strDataName & Chr(34))
                     clsSetDataFramesChanged.AddParameter("new_val", "FALSE")
                     frmMain.clsRLink.RunInternalScript(clsSetDataFramesChanged.ToScript())
@@ -181,10 +182,7 @@ Public Class clsGridLink
             grdVariablesMetadata.Visible = True
             grdMetadata.Visible = True
         End If
-        'TODO TEMPORARY THIS MUST BE REMOVED
-        'Cannot refer to frmEditor directly
-        'Could fix by having user control for grid and here raising event handled in frmEditor
-        frmEditor.UpdateCurrentWorksheet()
+        ucrDataViewer.UpdateCurrentWorksheet()
     End Sub
 
     Public Sub SetMetadata(tmpStrMetadata As String)
@@ -209,8 +207,9 @@ Public Class clsGridLink
         End If
     End Sub
 
-    Public Sub SetData(grdTemp As ReoGridControl)
-        grdData = grdTemp
+    Public Sub SetDataViewer(ucrNewDataViewer As ucrDataView)
+        ucrDataViewer = ucrNewDataViewer
+        grdData = ucrNewDataViewer.grdData
         bGrdDataExists = True
         bGrdDataChanged = True
         UpdateGrids()

--- a/instat/clsRLink.vb
+++ b/instat/clsRLink.vb
@@ -15,6 +15,7 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Imports RDotNet
+Imports unvell.ReoGrid
 
 Public Class RLink
     ' R interface class. Each instance of the class has its own REngine instance
@@ -44,6 +45,8 @@ Public Class RLink
 
     Public strGraphDisplayOption As String = "view_output_window"
 
+    Private grdDataView As ReoGridControl
+
     Public Sub New(Optional bWithInstatObj As Boolean = False, Optional bWithClimsoft As Boolean = False)
 
     End Sub
@@ -62,6 +65,10 @@ Public Class RLink
             Application.Exit()
         End Try
         clsEngine.Initialize()
+    End Sub
+
+    Public Sub SetDataViewGrid(grdNewDataGrid As ReoGridControl)
+        grdDataView = grdNewDataGrid
     End Sub
 
     Public Sub setFormatOutput(tempFont As Font, tempColor As Color)
@@ -127,8 +134,8 @@ Public Class RLink
             cboDataFrames.Items.AddRange(GetDataFrameNames().ToArray)
             AdjustComboBoxWidth(cboDataFrames)
             'Task/Question: From what I understood, if bSetDefault is true or if the strCurrentDataFrame (given as an argument) is actually not in cboDataFrames (is this case generic or should it never happen ?), then the selected Index should be the current worksheet.
-            If (bSetDefault OrElse cboDataFrames.Items.IndexOf(strCurrentDataFrame) = -1) AndAlso (frmEditor.grdData IsNot Nothing) AndAlso (frmEditor.grdData.CurrentWorksheet IsNot Nothing) Then
-                cboDataFrames.SelectedIndex = cboDataFrames.Items.IndexOf(frmEditor.grdData.CurrentWorksheet.Name)
+            If (bSetDefault OrElse cboDataFrames.Items.IndexOf(strCurrentDataFrame) = -1) AndAlso (grdDataView IsNot Nothing) AndAlso (grdDataView.CurrentWorksheet IsNot Nothing) Then
+                cboDataFrames.SelectedIndex = cboDataFrames.Items.IndexOf(grdDataView.CurrentWorksheet.Name)
             ElseIf cboDataFrames.Items.IndexOf(strCurrentDataFrame) <> -1 Then
                 cboDataFrames.SelectedIndex = cboDataFrames.Items.IndexOf(strCurrentDataFrame)
             End If
@@ -139,7 +146,7 @@ Public Class RLink
     ' Then this can be removed
     Public Shared Sub AdjustComboBoxWidth(cboCurrent As ComboBox)
         Dim iWidth As Integer = cboCurrent.DropDownWidth
-        Dim graTemp As Graphics = cboCurrent.CreateGraphics()
+        Dim graTemp As System.Drawing.Graphics = cboCurrent.CreateGraphics()
         Dim font As Font = cboCurrent.Font
         Dim iScrollBarWidth As Integer
         Dim iNewWidth As Integer
@@ -233,7 +240,7 @@ Public Class RLink
         Dim strTempGraphsDirectory As String
         Dim clsPNGFunction As New RFunction
 
-        strTempGraphsDirectory = IO.Path.Combine(IO.Path.GetTempPath() & "R_Instat_Temp_Graphs")
+        strTempGraphsDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath() & "R_Instat_Temp_Graphs")
         strOutput = ""
 
         If strComment <> "" Then
@@ -265,7 +272,7 @@ Public Class RLink
                 If iCallType = 3 Then
                     If strGraphDisplayOption = "view_output_window" OrElse strGraphDisplayOption = "view_separate_window" Then
                         clsPNGFunction.SetRCommand("png")
-                        clsPNGFunction.AddParameter("filename", Chr(34) & IO.Path.Combine(strTempGraphsDirectory & "/Graph.png").Replace("\", "/") & Chr(34))
+                        clsPNGFunction.AddParameter("filename", Chr(34) & System.IO.Path.Combine(strTempGraphsDirectory & "/Graph.png").Replace("\", "/") & Chr(34))
                         clsPNGFunction.AddParameter("width", 4000)
                         clsPNGFunction.AddParameter("height", 4000)
                         clsPNGFunction.AddParameter("res", 500)
@@ -284,7 +291,7 @@ Public Class RLink
                         'It is called from RLink at the end of RunScript.
                         Dim lstTempGraphFiles As ObjectModel.ReadOnlyCollection(Of String)
                         Dim iNumberOfFiles As Integer = -1
-                        strTempGraphsDirectory = IO.Path.Combine(IO.Path.GetTempPath(), "R_Instat_Temp_Graphs")
+                        strTempGraphsDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "R_Instat_Temp_Graphs")
                         Try
                             lstTempGraphFiles = FileIO.FileSystem.GetFiles(strTempGraphsDirectory)
                         Catch e As Exception

--- a/instat/frmEditor.vb
+++ b/instat/frmEditor.vb
@@ -44,7 +44,7 @@ Public Class frmEditor
     Private Sub frmEditor_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         FreezeToHereToolStripMenuItem.Enabled = False
         UnfreezeToolStripMenuItem.Enabled = False
-        frmMain.clsGrids.SetData(grdData)
+        'frmMain.clsGrids.SetData(grdData)
         grdData.Visible = False
         autoTranslate(Me)
         'Disable Autoformat cell
@@ -587,7 +587,7 @@ Public Class frmEditor
     End Sub
 
     Private Sub frmEditor_VisibleChanged(sender As Object, e As EventArgs) Handles Me.VisibleChanged
-        frmMain.mnuViewDataView.Checked = Me.Visible
+        'frmMain.mnuViewDataView.Checked = Me.Visible
     End Sub
 
     Private Sub clearColumnFilterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles clearColumnFilterToolStripMenuItem.Click

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -135,9 +135,6 @@ Partial Class frmMain
         Me.mnuViewColumnMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuViewDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator22 = New System.Windows.Forms.ToolStripSeparator()
-        Me.mnuViewCascade = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuViewTileVertically = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuViewTileHorizontally = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpHelpIntroduction = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpHistFAQ = New System.Windows.Forms.ToolStripMenuItem()
@@ -451,9 +448,35 @@ Partial Class frmMain
         Me.mnuToolsSaveCurrentOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsLoadOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsOptions = New System.Windows.Forms.ToolStripMenuItem()
+        Me.splOverall = New System.Windows.Forms.SplitContainer()
+        Me.splDataOutput = New System.Windows.Forms.SplitContainer()
+        Me.spltExtraWindows = New System.Windows.Forms.SplitContainer()
+        Me.splMetadata = New System.Windows.Forms.SplitContainer()
+        Me.splLogScript = New System.Windows.Forms.SplitContainer()
+        Me.ucrColumnMeta = New instat.ucrColumnMetadata()
+        Me.ucrDataViewer = New instat.ucrDataView()
+        Me.ucrOutput = New instat.ucrOutputWindow()
+        Me.ResetToDefaultLayoutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
+        CType(Me.splOverall, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splOverall.Panel1.SuspendLayout()
+        Me.splOverall.Panel2.SuspendLayout()
+        Me.splOverall.SuspendLayout()
+        CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splDataOutput.Panel1.SuspendLayout()
+        Me.splDataOutput.Panel2.SuspendLayout()
+        Me.splDataOutput.SuspendLayout()
+        CType(Me.spltExtraWindows, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.spltExtraWindows.Panel1.SuspendLayout()
+        Me.spltExtraWindows.Panel2.SuspendLayout()
+        Me.spltExtraWindows.SuspendLayout()
+        CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splMetadata.Panel1.SuspendLayout()
+        Me.splMetadata.SuspendLayout()
+        CType(Me.splLogScript, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splLogScript.SuspendLayout()
         Me.SuspendLayout()
         '
         'mnuDescribe
@@ -1212,7 +1235,7 @@ Partial Class frmMain
         '
         'mnuView
         '
-        Me.mnuView.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuViewDataView, Me.mnuViewOutputWindow, Me.mnuViewLog, Me.mnuViewScriptWindow, Me.mnuViewColumnMetadata, Me.mnuViewDataFrameMetadata, Me.ToolStripSeparator22, Me.mnuViewCascade, Me.mnuViewTileVertically, Me.mnuViewTileHorizontally})
+        Me.mnuView.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuViewDataView, Me.mnuViewOutputWindow, Me.mnuViewLog, Me.mnuViewScriptWindow, Me.mnuViewColumnMetadata, Me.mnuViewDataFrameMetadata, Me.ToolStripSeparator22, Me.ResetToDefaultLayoutToolStripMenuItem})
         Me.mnuView.Name = "mnuView"
         Me.mnuView.Size = New System.Drawing.Size(44, 20)
         Me.mnuView.Tag = "View"
@@ -1221,66 +1244,48 @@ Partial Class frmMain
         'mnuViewDataView
         '
         Me.mnuViewDataView.Name = "mnuViewDataView"
-        Me.mnuViewDataView.Size = New System.Drawing.Size(187, 22)
+        Me.mnuViewDataView.Size = New System.Drawing.Size(196, 22)
         Me.mnuViewDataView.Tag = "Data_View"
         Me.mnuViewDataView.Text = "Data View"
         '
         'mnuViewOutputWindow
         '
         Me.mnuViewOutputWindow.Name = "mnuViewOutputWindow"
-        Me.mnuViewOutputWindow.Size = New System.Drawing.Size(187, 22)
+        Me.mnuViewOutputWindow.Size = New System.Drawing.Size(196, 22)
         Me.mnuViewOutputWindow.Text = "Output Window"
         '
         'mnuViewLog
         '
         Me.mnuViewLog.Name = "mnuViewLog"
-        Me.mnuViewLog.Size = New System.Drawing.Size(187, 22)
+        Me.mnuViewLog.Size = New System.Drawing.Size(196, 22)
         Me.mnuViewLog.Tag = "Log"
         Me.mnuViewLog.Text = "Log Window"
         '
         'mnuViewScriptWindow
         '
         Me.mnuViewScriptWindow.Name = "mnuViewScriptWindow"
-        Me.mnuViewScriptWindow.Size = New System.Drawing.Size(187, 22)
+        Me.mnuViewScriptWindow.Size = New System.Drawing.Size(196, 22)
         Me.mnuViewScriptWindow.Tag = "Script_Window"
         Me.mnuViewScriptWindow.Text = "Script Window"
         '
         'mnuViewColumnMetadata
         '
         Me.mnuViewColumnMetadata.Name = "mnuViewColumnMetadata"
-        Me.mnuViewColumnMetadata.Size = New System.Drawing.Size(187, 22)
+        Me.mnuViewColumnMetadata.Size = New System.Drawing.Size(196, 22)
         Me.mnuViewColumnMetadata.Tag = "Column_Metadata"
         Me.mnuViewColumnMetadata.Text = "Column Metadata"
         '
         'mnuViewDataFrameMetadata
         '
         Me.mnuViewDataFrameMetadata.Name = "mnuViewDataFrameMetadata"
-        Me.mnuViewDataFrameMetadata.Size = New System.Drawing.Size(187, 22)
+        Me.mnuViewDataFrameMetadata.Size = New System.Drawing.Size(196, 22)
         Me.mnuViewDataFrameMetadata.Tag = "Data_Frame_Metadata"
         Me.mnuViewDataFrameMetadata.Text = "Data Frame Metadata"
         '
         'ToolStripSeparator22
         '
         Me.ToolStripSeparator22.Name = "ToolStripSeparator22"
-        Me.ToolStripSeparator22.Size = New System.Drawing.Size(184, 6)
-        '
-        'mnuViewCascade
-        '
-        Me.mnuViewCascade.Name = "mnuViewCascade"
-        Me.mnuViewCascade.Size = New System.Drawing.Size(187, 22)
-        Me.mnuViewCascade.Text = "Cascade"
-        '
-        'mnuViewTileVertically
-        '
-        Me.mnuViewTileVertically.Name = "mnuViewTileVertically"
-        Me.mnuViewTileVertically.Size = New System.Drawing.Size(187, 22)
-        Me.mnuViewTileVertically.Text = "Tile Vertically"
-        '
-        'mnuViewTileHorizontally
-        '
-        Me.mnuViewTileHorizontally.Name = "mnuViewTileHorizontally"
-        Me.mnuViewTileHorizontally.Size = New System.Drawing.Size(187, 22)
-        Me.mnuViewTileHorizontally.Text = "Tile Horizontally"
+        Me.ToolStripSeparator22.Size = New System.Drawing.Size(193, 6)
         '
         'mnuHelp
         '
@@ -2293,7 +2298,7 @@ Partial Class frmMain
         Me.stsStrip.Location = New System.Drawing.Point(0, 285)
         Me.stsStrip.Name = "stsStrip"
         Me.stsStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
-        Me.stsStrip.Size = New System.Drawing.Size(508, 22)
+        Me.stsStrip.Size = New System.Drawing.Size(600, 22)
         Me.stsStrip.TabIndex = 8
         Me.stsStrip.Text = "Status"
         '
@@ -2310,7 +2315,7 @@ Partial Class frmMain
         Me.Tool_strip.Location = New System.Drawing.Point(0, 24)
         Me.Tool_strip.Name = "Tool_strip"
         Me.Tool_strip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
-        Me.Tool_strip.Size = New System.Drawing.Size(508, 25)
+        Me.Tool_strip.Size = New System.Drawing.Size(600, 25)
         Me.Tool_strip.TabIndex = 7
         Me.Tool_strip.Text = "Tool"
         '
@@ -2454,7 +2459,7 @@ Partial Class frmMain
         Me.mnuBar.Name = "mnuBar"
         Me.mnuBar.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
         Me.mnuBar.ShowItemToolTips = True
-        Me.mnuBar.Size = New System.Drawing.Size(508, 24)
+        Me.mnuBar.Size = New System.Drawing.Size(600, 24)
         Me.mnuBar.TabIndex = 6
         Me.mnuBar.Text = "Menu_strip"
         '
@@ -3359,7 +3364,7 @@ Partial Class frmMain
         'AaToolStripMenuItem1
         '
         Me.AaToolStripMenuItem1.Name = "AaToolStripMenuItem1"
-        Me.AaToolStripMenuItem1.Size = New System.Drawing.Size(152, 22)
+        Me.AaToolStripMenuItem1.Size = New System.Drawing.Size(133, 22)
         Me.AaToolStripMenuItem1.Text = "Fit Model..."
         '
         'DefineRedFlagsToolStripMenuItem
@@ -3447,11 +3452,146 @@ Partial Class frmMain
         Me.mnuToolsOptions.Tag = "Options..."
         Me.mnuToolsOptions.Text = "Options..."
         '
+        'splOverall
+        '
+        Me.splOverall.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splOverall.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splOverall.Location = New System.Drawing.Point(0, 49)
+        Me.splOverall.Name = "splOverall"
+        Me.splOverall.Orientation = System.Windows.Forms.Orientation.Horizontal
+        '
+        'splOverall.Panel1
+        '
+        Me.splOverall.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splOverall.Panel1.Controls.Add(Me.spltExtraWindows)
+        '
+        'splOverall.Panel2
+        '
+        Me.splOverall.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splOverall.Panel2.Controls.Add(Me.splDataOutput)
+        Me.splOverall.Size = New System.Drawing.Size(600, 236)
+        Me.splOverall.SplitterDistance = 118
+        Me.splOverall.SplitterWidth = 10
+        Me.splOverall.TabIndex = 10
+        '
+        'splDataOutput
+        '
+        Me.splDataOutput.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splDataOutput.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splDataOutput.Location = New System.Drawing.Point(0, 0)
+        Me.splDataOutput.Name = "splDataOutput"
+        '
+        'splDataOutput.Panel1
+        '
+        Me.splDataOutput.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splDataOutput.Panel1.Controls.Add(Me.ucrDataViewer)
+        '
+        'splDataOutput.Panel2
+        '
+        Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
+        Me.splDataOutput.Size = New System.Drawing.Size(600, 108)
+        Me.splDataOutput.SplitterDistance = 300
+        Me.splDataOutput.TabIndex = 0
+        '
+        'spltExtraWindows
+        '
+        Me.spltExtraWindows.BackColor = System.Drawing.Color.DodgerBlue
+        Me.spltExtraWindows.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.spltExtraWindows.Location = New System.Drawing.Point(0, 0)
+        Me.spltExtraWindows.Name = "spltExtraWindows"
+        '
+        'spltExtraWindows.Panel1
+        '
+        Me.spltExtraWindows.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.spltExtraWindows.Panel1.Controls.Add(Me.splMetadata)
+        '
+        'spltExtraWindows.Panel2
+        '
+        Me.spltExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.spltExtraWindows.Panel2.Controls.Add(Me.splLogScript)
+        Me.spltExtraWindows.Size = New System.Drawing.Size(600, 118)
+        Me.spltExtraWindows.SplitterDistance = 200
+        Me.spltExtraWindows.TabIndex = 0
+        '
+        'splMetadata
+        '
+        Me.splMetadata.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splMetadata.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splMetadata.Location = New System.Drawing.Point(0, 0)
+        Me.splMetadata.Name = "splMetadata"
+        '
+        'splMetadata.Panel1
+        '
+        Me.splMetadata.Panel1.Controls.Add(Me.ucrColumnMeta)
+        '
+        'splMetadata.Panel2
+        '
+        Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splMetadata.Size = New System.Drawing.Size(200, 118)
+        Me.splMetadata.SplitterDistance = 66
+        Me.splMetadata.TabIndex = 0
+        '
+        'splLogScript
+        '
+        Me.splLogScript.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splLogScript.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splLogScript.Location = New System.Drawing.Point(0, 0)
+        Me.splLogScript.Name = "splLogScript"
+        '
+        'splLogScript.Panel1
+        '
+        Me.splLogScript.Panel1.BackColor = System.Drawing.SystemColors.Control
+        '
+        'splLogScript.Panel2
+        '
+        Me.splLogScript.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splLogScript.Size = New System.Drawing.Size(396, 118)
+        Me.splLogScript.SplitterDistance = 132
+        Me.splLogScript.TabIndex = 0
+        '
+        'ucrColumnMeta
+        '
+        Me.ucrColumnMeta.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
+        Me.ucrColumnMeta.Name = "ucrColumnMeta"
+        Me.ucrColumnMeta.Size = New System.Drawing.Size(66, 118)
+        Me.ucrColumnMeta.TabIndex = 0
+        '
+        'ucrDataViewer
+        '
+        Me.ucrDataViewer.BackColor = System.Drawing.SystemColors.Control
+        Me.ucrDataViewer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
+        Me.ucrDataViewer.Name = "ucrDataViewer"
+        Me.ucrDataViewer.Padding = New System.Windows.Forms.Padding(0, 5, 0, 0)
+        Me.ucrDataViewer.Size = New System.Drawing.Size(300, 108)
+        Me.ucrDataViewer.TabIndex = 0
+        Me.ucrDataViewer.Tag = "Data_View"
+        '
+        'ucrOutput
+        '
+        Me.ucrOutput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrOutput.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrOutput.Location = New System.Drawing.Point(0, 0)
+        Me.ucrOutput.Name = "ucrOutput"
+        Me.ucrOutput.Padding = New System.Windows.Forms.Padding(0, 5, 0, 0)
+        Me.ucrOutput.Size = New System.Drawing.Size(296, 108)
+        Me.ucrOutput.TabIndex = 0
+        '
+        'ResetToDefaultLayoutToolStripMenuItem
+        '
+        Me.ResetToDefaultLayoutToolStripMenuItem.Name = "ResetToDefaultLayoutToolStripMenuItem"
+        Me.ResetToDefaultLayoutToolStripMenuItem.Size = New System.Drawing.Size(196, 22)
+        Me.ResetToDefaultLayoutToolStripMenuItem.Text = "Reset to Default Layout"
+        '
         'frmMain
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(508, 307)
+        Me.ClientSize = New System.Drawing.Size(600, 307)
+        Me.Controls.Add(Me.splOverall)
         Me.Controls.Add(Me.stsStrip)
         Me.Controls.Add(Me.Tool_strip)
         Me.Controls.Add(Me.mnuBar)
@@ -3467,6 +3607,23 @@ Partial Class frmMain
         Me.Tool_strip.PerformLayout()
         Me.mnuBar.ResumeLayout(False)
         Me.mnuBar.PerformLayout()
+        Me.splOverall.Panel1.ResumeLayout(False)
+        Me.splOverall.Panel2.ResumeLayout(False)
+        CType(Me.splOverall, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splOverall.ResumeLayout(False)
+        Me.splDataOutput.Panel1.ResumeLayout(False)
+        Me.splDataOutput.Panel2.ResumeLayout(False)
+        CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splDataOutput.ResumeLayout(False)
+        Me.spltExtraWindows.Panel1.ResumeLayout(False)
+        Me.spltExtraWindows.Panel2.ResumeLayout(False)
+        CType(Me.spltExtraWindows, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.spltExtraWindows.ResumeLayout(False)
+        Me.splMetadata.Panel1.ResumeLayout(False)
+        CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splMetadata.ResumeLayout(False)
+        CType(Me.splLogScript, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splLogScript.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -3700,9 +3857,6 @@ Partial Class frmMain
     Friend WithEvents mnuPreparePrepareToShareJitter As ToolStripMenuItem
     Friend WithEvents mnuCheckDataPrePareToShareSdcPackage As ToolStripMenuItem
     Friend WithEvents ColourByPropertyToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents mnuViewCascade As ToolStripMenuItem
-    Friend WithEvents mnuViewTileVertically As ToolStripMenuItem
-    Friend WithEvents mnuViewTileHorizontally As ToolStripMenuItem
     Friend WithEvents mnuPrepareDataObjectHideDataframes As ToolStripMenuItem
     Friend WithEvents mnuPrepareAppendDataFrame As ToolStripMenuItem
     Friend WithEvents mnuFileSaveAsDataAs As ToolStripMenuItem
@@ -3901,4 +4055,13 @@ Partial Class frmMain
     Friend WithEvents ToolStripSeparator36 As ToolStripSeparator
     Friend WithEvents mnuDescribeThreeVariableFrequencies As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator35 As ToolStripSeparator
+    Friend WithEvents splOverall As SplitContainer
+    Friend WithEvents splDataOutput As SplitContainer
+    Friend WithEvents ucrDataViewer As ucrDataView
+    Friend WithEvents ucrOutput As ucrOutputWindow
+    Friend WithEvents spltExtraWindows As SplitContainer
+    Friend WithEvents splMetadata As SplitContainer
+    Friend WithEvents splLogScript As SplitContainer
+    Friend WithEvents ucrColumnMeta As ucrColumnMetadata
+    Friend WithEvents ResetToDefaultLayoutToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -3483,7 +3483,7 @@ Partial Class frmMain
         Me.splOverall.Panel2.Controls.Add(Me.splDataOutput)
         Me.splOverall.Size = New System.Drawing.Size(600, 236)
         Me.splOverall.SplitterDistance = 118
-        Me.splOverall.SplitterWidth = 10
+        Me.splOverall.SplitterWidth = 5
         Me.splOverall.TabIndex = 10
         '
         'splExtraWindows
@@ -3504,6 +3504,7 @@ Partial Class frmMain
         Me.splExtraWindows.Panel2.Controls.Add(Me.splLogScript)
         Me.splExtraWindows.Size = New System.Drawing.Size(600, 118)
         Me.splExtraWindows.SplitterDistance = 200
+        Me.splExtraWindows.SplitterWidth = 5
         Me.splExtraWindows.TabIndex = 0
         '
         'splMetadata
@@ -3523,6 +3524,7 @@ Partial Class frmMain
         Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
         Me.splMetadata.Size = New System.Drawing.Size(200, 118)
         Me.splMetadata.SplitterDistance = 66
+        Me.splMetadata.SplitterWidth = 5
         Me.splMetadata.TabIndex = 0
         '
         'splLogScript
@@ -3541,8 +3543,9 @@ Partial Class frmMain
         '
         Me.splLogScript.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splLogScript.Panel2.Controls.Add(Me.ucrScriptWindow)
-        Me.splLogScript.Size = New System.Drawing.Size(396, 118)
-        Me.splLogScript.SplitterDistance = 132
+        Me.splLogScript.Size = New System.Drawing.Size(395, 118)
+        Me.splLogScript.SplitterDistance = 131
+        Me.splLogScript.SplitterWidth = 5
         Me.splLogScript.TabIndex = 0
         '
         'splDataOutput
@@ -3561,8 +3564,9 @@ Partial Class frmMain
         '
         Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
-        Me.splDataOutput.Size = New System.Drawing.Size(600, 108)
+        Me.splDataOutput.Size = New System.Drawing.Size(600, 113)
         Me.splDataOutput.SplitterDistance = 300
+        Me.splDataOutput.SplitterWidth = 5
         Me.splDataOutput.TabIndex = 0
         '
         'ucrColumnMeta
@@ -3580,7 +3584,7 @@ Partial Class frmMain
         Me.ucrDataFrameMeta.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
         Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
-        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(130, 118)
+        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(129, 118)
         Me.ucrDataFrameMeta.TabIndex = 0
         '
         'ucrLogWindow
@@ -3589,7 +3593,7 @@ Partial Class frmMain
         Me.ucrLogWindow.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrLogWindow.Location = New System.Drawing.Point(0, 0)
         Me.ucrLogWindow.Name = "ucrLogWindow"
-        Me.ucrLogWindow.Size = New System.Drawing.Size(132, 118)
+        Me.ucrLogWindow.Size = New System.Drawing.Size(131, 118)
         Me.ucrLogWindow.TabIndex = 0
         '
         'ucrScriptWindow
@@ -3598,7 +3602,7 @@ Partial Class frmMain
         Me.ucrScriptWindow.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
         Me.ucrScriptWindow.Name = "ucrScriptWindow"
-        Me.ucrScriptWindow.Size = New System.Drawing.Size(260, 118)
+        Me.ucrScriptWindow.Size = New System.Drawing.Size(259, 118)
         Me.ucrScriptWindow.TabIndex = 0
         Me.ucrScriptWindow.Tag = "Script_Window"
         '
@@ -3609,7 +3613,7 @@ Partial Class frmMain
         Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
         Me.ucrDataViewer.Name = "ucrDataViewer"
-        Me.ucrDataViewer.Size = New System.Drawing.Size(300, 108)
+        Me.ucrDataViewer.Size = New System.Drawing.Size(300, 113)
         Me.ucrDataViewer.TabIndex = 0
         Me.ucrDataViewer.Tag = "Data_View"
         '
@@ -3619,7 +3623,7 @@ Partial Class frmMain
         Me.ucrOutput.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrOutput.Location = New System.Drawing.Point(0, 0)
         Me.ucrOutput.Name = "ucrOutput"
-        Me.ucrOutput.Size = New System.Drawing.Size(296, 108)
+        Me.ucrOutput.Size = New System.Drawing.Size(295, 113)
         Me.ucrOutput.TabIndex = 0
         '
         'frmMain

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -135,6 +135,7 @@ Partial Class frmMain
         Me.mnuViewColumnMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuViewDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator22 = New System.Windows.Forms.ToolStripSeparator()
+        Me.ResetToDefaultLayoutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpHelpIntroduction = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpHistFAQ = New System.Windows.Forms.ToolStripMenuItem()
@@ -449,14 +450,16 @@ Partial Class frmMain
         Me.mnuToolsLoadOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.splOverall = New System.Windows.Forms.SplitContainer()
-        Me.splDataOutput = New System.Windows.Forms.SplitContainer()
-        Me.spltExtraWindows = New System.Windows.Forms.SplitContainer()
+        Me.splExtraWindows = New System.Windows.Forms.SplitContainer()
         Me.splMetadata = New System.Windows.Forms.SplitContainer()
         Me.splLogScript = New System.Windows.Forms.SplitContainer()
+        Me.splDataOutput = New System.Windows.Forms.SplitContainer()
         Me.ucrColumnMeta = New instat.ucrColumnMetadata()
+        Me.ucrDataFrameMeta = New instat.ucrDataFrameMetadata()
+        Me.ucrLogWindow = New instat.ucrLog()
+        Me.ucrScriptWindow = New instat.ucrScript()
         Me.ucrDataViewer = New instat.ucrDataView()
         Me.ucrOutput = New instat.ucrOutputWindow()
-        Me.ResetToDefaultLayoutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -464,19 +467,22 @@ Partial Class frmMain
         Me.splOverall.Panel1.SuspendLayout()
         Me.splOverall.Panel2.SuspendLayout()
         Me.splOverall.SuspendLayout()
+        CType(Me.splExtraWindows, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splExtraWindows.Panel1.SuspendLayout()
+        Me.splExtraWindows.Panel2.SuspendLayout()
+        Me.splExtraWindows.SuspendLayout()
+        CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splMetadata.Panel1.SuspendLayout()
+        Me.splMetadata.Panel2.SuspendLayout()
+        Me.splMetadata.SuspendLayout()
+        CType(Me.splLogScript, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splLogScript.Panel1.SuspendLayout()
+        Me.splLogScript.Panel2.SuspendLayout()
+        Me.splLogScript.SuspendLayout()
         CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.splDataOutput.Panel1.SuspendLayout()
         Me.splDataOutput.Panel2.SuspendLayout()
         Me.splDataOutput.SuspendLayout()
-        CType(Me.spltExtraWindows, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.spltExtraWindows.Panel1.SuspendLayout()
-        Me.spltExtraWindows.Panel2.SuspendLayout()
-        Me.spltExtraWindows.SuspendLayout()
-        CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.splMetadata.Panel1.SuspendLayout()
-        Me.splMetadata.SuspendLayout()
-        CType(Me.splLogScript, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.splLogScript.SuspendLayout()
         Me.SuspendLayout()
         '
         'mnuDescribe
@@ -1286,6 +1292,12 @@ Partial Class frmMain
         '
         Me.ToolStripSeparator22.Name = "ToolStripSeparator22"
         Me.ToolStripSeparator22.Size = New System.Drawing.Size(193, 6)
+        '
+        'ResetToDefaultLayoutToolStripMenuItem
+        '
+        Me.ResetToDefaultLayoutToolStripMenuItem.Name = "ResetToDefaultLayoutToolStripMenuItem"
+        Me.ResetToDefaultLayoutToolStripMenuItem.Size = New System.Drawing.Size(196, 22)
+        Me.ResetToDefaultLayoutToolStripMenuItem.Text = "Reset to Default Layout"
         '
         'mnuHelp
         '
@@ -3463,7 +3475,7 @@ Partial Class frmMain
         'splOverall.Panel1
         '
         Me.splOverall.Panel1.BackColor = System.Drawing.SystemColors.Control
-        Me.splOverall.Panel1.Controls.Add(Me.spltExtraWindows)
+        Me.splOverall.Panel1.Controls.Add(Me.splExtraWindows)
         '
         'splOverall.Panel2
         '
@@ -3473,6 +3485,65 @@ Partial Class frmMain
         Me.splOverall.SplitterDistance = 118
         Me.splOverall.SplitterWidth = 10
         Me.splOverall.TabIndex = 10
+        '
+        'splExtraWindows
+        '
+        Me.splExtraWindows.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splExtraWindows.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splExtraWindows.Location = New System.Drawing.Point(0, 0)
+        Me.splExtraWindows.Name = "splExtraWindows"
+        '
+        'splExtraWindows.Panel1
+        '
+        Me.splExtraWindows.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splExtraWindows.Panel1.Controls.Add(Me.splMetadata)
+        '
+        'splExtraWindows.Panel2
+        '
+        Me.splExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splExtraWindows.Panel2.Controls.Add(Me.splLogScript)
+        Me.splExtraWindows.Size = New System.Drawing.Size(600, 118)
+        Me.splExtraWindows.SplitterDistance = 200
+        Me.splExtraWindows.TabIndex = 0
+        '
+        'splMetadata
+        '
+        Me.splMetadata.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splMetadata.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splMetadata.Location = New System.Drawing.Point(0, 0)
+        Me.splMetadata.Name = "splMetadata"
+        '
+        'splMetadata.Panel1
+        '
+        Me.splMetadata.Panel1.Controls.Add(Me.ucrColumnMeta)
+        '
+        'splMetadata.Panel2
+        '
+        Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
+        Me.splMetadata.Size = New System.Drawing.Size(200, 118)
+        Me.splMetadata.SplitterDistance = 66
+        Me.splMetadata.TabIndex = 0
+        '
+        'splLogScript
+        '
+        Me.splLogScript.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splLogScript.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splLogScript.Location = New System.Drawing.Point(0, 0)
+        Me.splLogScript.Name = "splLogScript"
+        '
+        'splLogScript.Panel1
+        '
+        Me.splLogScript.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splLogScript.Panel1.Controls.Add(Me.ucrLogWindow)
+        '
+        'splLogScript.Panel2
+        '
+        Me.splLogScript.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splLogScript.Panel2.Controls.Add(Me.ucrScriptWindow)
+        Me.splLogScript.Size = New System.Drawing.Size(396, 118)
+        Me.splLogScript.SplitterDistance = 132
+        Me.splLogScript.TabIndex = 0
         '
         'splDataOutput
         '
@@ -3494,69 +3565,42 @@ Partial Class frmMain
         Me.splDataOutput.SplitterDistance = 300
         Me.splDataOutput.TabIndex = 0
         '
-        'spltExtraWindows
-        '
-        Me.spltExtraWindows.BackColor = System.Drawing.Color.DodgerBlue
-        Me.spltExtraWindows.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.spltExtraWindows.Location = New System.Drawing.Point(0, 0)
-        Me.spltExtraWindows.Name = "spltExtraWindows"
-        '
-        'spltExtraWindows.Panel1
-        '
-        Me.spltExtraWindows.Panel1.BackColor = System.Drawing.SystemColors.Control
-        Me.spltExtraWindows.Panel1.Controls.Add(Me.splMetadata)
-        '
-        'spltExtraWindows.Panel2
-        '
-        Me.spltExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.spltExtraWindows.Panel2.Controls.Add(Me.splLogScript)
-        Me.spltExtraWindows.Size = New System.Drawing.Size(600, 118)
-        Me.spltExtraWindows.SplitterDistance = 200
-        Me.spltExtraWindows.TabIndex = 0
-        '
-        'splMetadata
-        '
-        Me.splMetadata.BackColor = System.Drawing.Color.DodgerBlue
-        Me.splMetadata.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.splMetadata.Location = New System.Drawing.Point(0, 0)
-        Me.splMetadata.Name = "splMetadata"
-        '
-        'splMetadata.Panel1
-        '
-        Me.splMetadata.Panel1.Controls.Add(Me.ucrColumnMeta)
-        '
-        'splMetadata.Panel2
-        '
-        Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.splMetadata.Size = New System.Drawing.Size(200, 118)
-        Me.splMetadata.SplitterDistance = 66
-        Me.splMetadata.TabIndex = 0
-        '
-        'splLogScript
-        '
-        Me.splLogScript.BackColor = System.Drawing.Color.DodgerBlue
-        Me.splLogScript.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.splLogScript.Location = New System.Drawing.Point(0, 0)
-        Me.splLogScript.Name = "splLogScript"
-        '
-        'splLogScript.Panel1
-        '
-        Me.splLogScript.Panel1.BackColor = System.Drawing.SystemColors.Control
-        '
-        'splLogScript.Panel2
-        '
-        Me.splLogScript.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.splLogScript.Size = New System.Drawing.Size(396, 118)
-        Me.splLogScript.SplitterDistance = 132
-        Me.splLogScript.TabIndex = 0
-        '
         'ucrColumnMeta
         '
+        Me.ucrColumnMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrColumnMeta.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
         Me.ucrColumnMeta.Name = "ucrColumnMeta"
         Me.ucrColumnMeta.Size = New System.Drawing.Size(66, 118)
         Me.ucrColumnMeta.TabIndex = 0
+        '
+        'ucrDataFrameMeta
+        '
+        Me.ucrDataFrameMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrDataFrameMeta.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
+        Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
+        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(130, 118)
+        Me.ucrDataFrameMeta.TabIndex = 0
+        '
+        'ucrLogWindow
+        '
+        Me.ucrLogWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrLogWindow.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrLogWindow.Location = New System.Drawing.Point(0, 0)
+        Me.ucrLogWindow.Name = "ucrLogWindow"
+        Me.ucrLogWindow.Size = New System.Drawing.Size(132, 118)
+        Me.ucrLogWindow.TabIndex = 0
+        '
+        'ucrScriptWindow
+        '
+        Me.ucrScriptWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrScriptWindow.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
+        Me.ucrScriptWindow.Name = "ucrScriptWindow"
+        Me.ucrScriptWindow.Size = New System.Drawing.Size(260, 118)
+        Me.ucrScriptWindow.TabIndex = 0
+        Me.ucrScriptWindow.Tag = "Script_Window"
         '
         'ucrDataViewer
         '
@@ -3565,7 +3609,6 @@ Partial Class frmMain
         Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
         Me.ucrDataViewer.Name = "ucrDataViewer"
-        Me.ucrDataViewer.Padding = New System.Windows.Forms.Padding(0, 5, 0, 0)
         Me.ucrDataViewer.Size = New System.Drawing.Size(300, 108)
         Me.ucrDataViewer.TabIndex = 0
         Me.ucrDataViewer.Tag = "Data_View"
@@ -3576,15 +3619,8 @@ Partial Class frmMain
         Me.ucrOutput.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrOutput.Location = New System.Drawing.Point(0, 0)
         Me.ucrOutput.Name = "ucrOutput"
-        Me.ucrOutput.Padding = New System.Windows.Forms.Padding(0, 5, 0, 0)
         Me.ucrOutput.Size = New System.Drawing.Size(296, 108)
         Me.ucrOutput.TabIndex = 0
-        '
-        'ResetToDefaultLayoutToolStripMenuItem
-        '
-        Me.ResetToDefaultLayoutToolStripMenuItem.Name = "ResetToDefaultLayoutToolStripMenuItem"
-        Me.ResetToDefaultLayoutToolStripMenuItem.Size = New System.Drawing.Size(196, 22)
-        Me.ResetToDefaultLayoutToolStripMenuItem.Text = "Reset to Default Layout"
         '
         'frmMain
         '
@@ -3611,19 +3647,22 @@ Partial Class frmMain
         Me.splOverall.Panel2.ResumeLayout(False)
         CType(Me.splOverall, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splOverall.ResumeLayout(False)
+        Me.splExtraWindows.Panel1.ResumeLayout(False)
+        Me.splExtraWindows.Panel2.ResumeLayout(False)
+        CType(Me.splExtraWindows, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splExtraWindows.ResumeLayout(False)
+        Me.splMetadata.Panel1.ResumeLayout(False)
+        Me.splMetadata.Panel2.ResumeLayout(False)
+        CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splMetadata.ResumeLayout(False)
+        Me.splLogScript.Panel1.ResumeLayout(False)
+        Me.splLogScript.Panel2.ResumeLayout(False)
+        CType(Me.splLogScript, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.splLogScript.ResumeLayout(False)
         Me.splDataOutput.Panel1.ResumeLayout(False)
         Me.splDataOutput.Panel2.ResumeLayout(False)
         CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splDataOutput.ResumeLayout(False)
-        Me.spltExtraWindows.Panel1.ResumeLayout(False)
-        Me.spltExtraWindows.Panel2.ResumeLayout(False)
-        CType(Me.spltExtraWindows, System.ComponentModel.ISupportInitialize).EndInit()
-        Me.spltExtraWindows.ResumeLayout(False)
-        Me.splMetadata.Panel1.ResumeLayout(False)
-        CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).EndInit()
-        Me.splMetadata.ResumeLayout(False)
-        CType(Me.splLogScript, System.ComponentModel.ISupportInitialize).EndInit()
-        Me.splLogScript.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -4059,9 +4098,12 @@ Partial Class frmMain
     Friend WithEvents splDataOutput As SplitContainer
     Friend WithEvents ucrDataViewer As ucrDataView
     Friend WithEvents ucrOutput As ucrOutputWindow
-    Friend WithEvents spltExtraWindows As SplitContainer
+    Friend WithEvents splExtraWindows As SplitContainer
     Friend WithEvents splMetadata As SplitContainer
     Friend WithEvents splLogScript As SplitContainer
     Friend WithEvents ucrColumnMeta As ucrColumnMetadata
     Friend WithEvents ResetToDefaultLayoutToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ucrDataFrameMeta As ucrDataFrameMetadata
+    Friend WithEvents ucrLogWindow As ucrLog
+    Friend WithEvents ucrScriptWindow As ucrScript
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -452,12 +452,12 @@ Partial Class frmMain
         Me.splOverall = New System.Windows.Forms.SplitContainer()
         Me.splExtraWindows = New System.Windows.Forms.SplitContainer()
         Me.splMetadata = New System.Windows.Forms.SplitContainer()
-        Me.splLogScript = New System.Windows.Forms.SplitContainer()
-        Me.splDataOutput = New System.Windows.Forms.SplitContainer()
         Me.ucrColumnMeta = New instat.ucrColumnMetadata()
         Me.ucrDataFrameMeta = New instat.ucrDataFrameMetadata()
+        Me.splLogScript = New System.Windows.Forms.SplitContainer()
         Me.ucrLogWindow = New instat.ucrLog()
         Me.ucrScriptWindow = New instat.ucrScript()
+        Me.splDataOutput = New System.Windows.Forms.SplitContainer()
         Me.ucrDataViewer = New instat.ucrDataView()
         Me.ucrOutput = New instat.ucrOutputWindow()
         Me.stsStrip.SuspendLayout()
@@ -3466,7 +3466,7 @@ Partial Class frmMain
         '
         'splOverall
         '
-        Me.splOverall.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splOverall.BackColor = System.Drawing.Color.LightGray
         Me.splOverall.Dock = System.Windows.Forms.DockStyle.Fill
         Me.splOverall.Location = New System.Drawing.Point(0, 49)
         Me.splOverall.Name = "splOverall"
@@ -3488,7 +3488,7 @@ Partial Class frmMain
         '
         'splExtraWindows
         '
-        Me.splExtraWindows.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splExtraWindows.BackColor = System.Drawing.Color.LightGray
         Me.splExtraWindows.Dock = System.Windows.Forms.DockStyle.Fill
         Me.splExtraWindows.Location = New System.Drawing.Point(0, 0)
         Me.splExtraWindows.Name = "splExtraWindows"
@@ -3509,7 +3509,7 @@ Partial Class frmMain
         '
         'splMetadata
         '
-        Me.splMetadata.BackColor = System.Drawing.Color.DodgerBlue
+        Me.splMetadata.BackColor = System.Drawing.Color.LightGray
         Me.splMetadata.Dock = System.Windows.Forms.DockStyle.Fill
         Me.splMetadata.Location = New System.Drawing.Point(0, 0)
         Me.splMetadata.Name = "splMetadata"
@@ -3526,48 +3526,6 @@ Partial Class frmMain
         Me.splMetadata.SplitterDistance = 66
         Me.splMetadata.SplitterWidth = 5
         Me.splMetadata.TabIndex = 0
-        '
-        'splLogScript
-        '
-        Me.splLogScript.BackColor = System.Drawing.Color.DodgerBlue
-        Me.splLogScript.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.splLogScript.Location = New System.Drawing.Point(0, 0)
-        Me.splLogScript.Name = "splLogScript"
-        '
-        'splLogScript.Panel1
-        '
-        Me.splLogScript.Panel1.BackColor = System.Drawing.SystemColors.Control
-        Me.splLogScript.Panel1.Controls.Add(Me.ucrLogWindow)
-        '
-        'splLogScript.Panel2
-        '
-        Me.splLogScript.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.splLogScript.Panel2.Controls.Add(Me.ucrScriptWindow)
-        Me.splLogScript.Size = New System.Drawing.Size(395, 118)
-        Me.splLogScript.SplitterDistance = 131
-        Me.splLogScript.SplitterWidth = 5
-        Me.splLogScript.TabIndex = 0
-        '
-        'splDataOutput
-        '
-        Me.splDataOutput.BackColor = System.Drawing.Color.DodgerBlue
-        Me.splDataOutput.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.splDataOutput.Location = New System.Drawing.Point(0, 0)
-        Me.splDataOutput.Name = "splDataOutput"
-        '
-        'splDataOutput.Panel1
-        '
-        Me.splDataOutput.Panel1.BackColor = System.Drawing.SystemColors.Control
-        Me.splDataOutput.Panel1.Controls.Add(Me.ucrDataViewer)
-        '
-        'splDataOutput.Panel2
-        '
-        Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
-        Me.splDataOutput.Size = New System.Drawing.Size(600, 113)
-        Me.splDataOutput.SplitterDistance = 300
-        Me.splDataOutput.SplitterWidth = 5
-        Me.splDataOutput.TabIndex = 0
         '
         'ucrColumnMeta
         '
@@ -3587,6 +3545,27 @@ Partial Class frmMain
         Me.ucrDataFrameMeta.Size = New System.Drawing.Size(129, 118)
         Me.ucrDataFrameMeta.TabIndex = 0
         '
+        'splLogScript
+        '
+        Me.splLogScript.BackColor = System.Drawing.Color.LightGray
+        Me.splLogScript.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splLogScript.Location = New System.Drawing.Point(0, 0)
+        Me.splLogScript.Name = "splLogScript"
+        '
+        'splLogScript.Panel1
+        '
+        Me.splLogScript.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splLogScript.Panel1.Controls.Add(Me.ucrLogWindow)
+        '
+        'splLogScript.Panel2
+        '
+        Me.splLogScript.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splLogScript.Panel2.Controls.Add(Me.ucrScriptWindow)
+        Me.splLogScript.Size = New System.Drawing.Size(395, 118)
+        Me.splLogScript.SplitterDistance = 131
+        Me.splLogScript.SplitterWidth = 5
+        Me.splLogScript.TabIndex = 0
+        '
         'ucrLogWindow
         '
         Me.ucrLogWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
@@ -3605,6 +3584,27 @@ Partial Class frmMain
         Me.ucrScriptWindow.Size = New System.Drawing.Size(259, 118)
         Me.ucrScriptWindow.TabIndex = 0
         Me.ucrScriptWindow.Tag = "Script_Window"
+        '
+        'splDataOutput
+        '
+        Me.splDataOutput.BackColor = System.Drawing.Color.LightGray
+        Me.splDataOutput.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.splDataOutput.Location = New System.Drawing.Point(0, 0)
+        Me.splDataOutput.Name = "splDataOutput"
+        '
+        'splDataOutput.Panel1
+        '
+        Me.splDataOutput.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splDataOutput.Panel1.Controls.Add(Me.ucrDataViewer)
+        '
+        'splDataOutput.Panel2
+        '
+        Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
+        Me.splDataOutput.Size = New System.Drawing.Size(600, 113)
+        Me.splDataOutput.SplitterDistance = 300
+        Me.splDataOutput.SplitterWidth = 5
+        Me.splDataOutput.TabIndex = 0
         '
         'ucrDataViewer
         '

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -1146,6 +1146,12 @@
     <Compile Include="ucrCore.vb">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="ucrDataFrameMetadata.Designer.vb">
+      <DependentUpon>ucrDataFrameMetadata.vb</DependentUpon>
+    </Compile>
+    <Compile Include="ucrDataFrameMetadata.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="ucrDataView.Designer.vb">
       <DependentUpon>ucrDataView.vb</DependentUpon>
     </Compile>
@@ -1934,6 +1940,12 @@
     <Compile Include="ucrLayerParamsControls.vb">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="ucrLog.Designer.vb">
+      <DependentUpon>ucrLog.vb</DependentUpon>
+    </Compile>
+    <Compile Include="ucrLog.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="ucrMultipleInput.Designer.vb">
       <DependentUpon>ucrMultipleInput.vb</DependentUpon>
     </Compile>
@@ -2016,6 +2028,12 @@
       <DependentUpon>ucrSaveModel.vb</DependentUpon>
     </Compile>
     <Compile Include="ucrSaveModel.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ucrScript.Designer.vb">
+      <DependentUpon>ucrScript.vb</DependentUpon>
+    </Compile>
+    <Compile Include="ucrScript.vb">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="ucrSelector.designer.vb">
@@ -4333,6 +4351,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ucrSaveModel.sw-KE.resx">
       <DependentUpon>ucrSaveModel.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ucrScript.resx">
+      <DependentUpon>ucrScript.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="ucrSelector.fr-FR.resx">
       <DependentUpon>ucrSelector.vb</DependentUpon>

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -4135,6 +4135,9 @@
     <EmbeddedResource Include="ucrDataFrameLength.sw-KE.resx">
       <DependentUpon>ucrDataFrameLength.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="ucrDataFrameMetadata.resx">
+      <DependentUpon>ucrDataFrameMetadata.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ucrDataSelection.fr-FR.resx">
       <DependentUpon>ucrDataSelection.vb</DependentUpon>
     </EmbeddedResource>
@@ -4264,6 +4267,9 @@
     <EmbeddedResource Include="ucrLayerParamsControls.sw-KE.resx">
       <DependentUpon>ucrLayerParamsControls.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="ucrLog.resx">
+      <DependentUpon>ucrLog.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ucrMultipleInput.fr-FR.resx">
       <DependentUpon>ucrMultipleInput.vb</DependentUpon>
     </EmbeddedResource>
@@ -4284,6 +4290,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ucrNud.resx">
       <DependentUpon>ucrNud.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ucrOutputWindow.resx">
+      <DependentUpon>ucrOutputWindow.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="ucrRadio.resx">
       <DependentUpon>ucrRadio.vb</DependentUpon>

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -4114,6 +4114,9 @@
     <EmbeddedResource Include="ucrColors.sw-KE.resx">
       <DependentUpon>ucrColors.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="ucrColumnMetadata.resx">
+      <DependentUpon>ucrColumnMetadata.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ucrDataFrame.fr-FR.resx">
       <DependentUpon>ucrDataFrame.vb</DependentUpon>
     </EmbeddedResource>

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -1134,10 +1134,22 @@
     <Compile Include="ucrColors.vb">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="ucrColumnMetadata.Designer.vb">
+      <DependentUpon>ucrColumnMetadata.vb</DependentUpon>
+    </Compile>
+    <Compile Include="ucrColumnMetadata.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="ucrCore.Designer.vb">
       <DependentUpon>ucrCore.vb</DependentUpon>
     </Compile>
     <Compile Include="ucrCore.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ucrDataView.Designer.vb">
+      <DependentUpon>ucrDataView.vb</DependentUpon>
+    </Compile>
+    <Compile Include="ucrDataView.vb">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="ucrDialogDisabled.Designer.vb">
@@ -1938,6 +1950,12 @@
       <DependentUpon>ucrNud.vb</DependentUpon>
     </Compile>
     <Compile Include="ucrNud.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ucrOutputWindow.Designer.vb">
+      <DependentUpon>ucrOutputWindow.vb</DependentUpon>
+    </Compile>
+    <Compile Include="ucrOutputWindow.vb">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="ucrRadio.Designer.vb">
@@ -4104,6 +4122,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ucrDataSelection.sw-KE.resx">
       <DependentUpon>ucrDataSelection.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ucrDataView.resx">
+      <DependentUpon>ucrDataView.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="ucrDialogDisabled.fr-FR.resx">
       <DependentUpon>ucrDialogDisabled.vb</DependentUpon>

--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -129,11 +129,8 @@ Public Class ucrButtons
     End Sub
 
     Private Sub cmdPaste_Click(sender As Object, e As EventArgs) Handles cmdPaste.Click
-        frmScript.txtScript.Text = frmScript.txtScript.Text & vbCrLf & "# " & txtComment.Text
-        frmScript.txtScript.Text = frmScript.txtScript.Text & vbCrLf & clsRsyntax.GetScript()
         'here we getscript but we don't reinitialise the AssignTo etc. for when pressing OK button ? ...
-        frmScript.Visible = True
-        frmScript.BringToFront()
+        frmMain.AddToScriptWindow("# " & txtComment.Text & vbCrLf & clsRsyntax.GetScript())
     End Sub
 
     Private Sub chkComment_CheckedChanged(sender As Object, e As EventArgs) Handles chkComment.CheckedChanged

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -23,15 +23,18 @@ Partial Class ucrColumnMetadata
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.grdVariables = New unvell.ReoGrid.ReoGridControl()
+        Me.lblHeader = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'grdVariables
         '
+        Me.grdVariables.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.grdVariables.BackColor = System.Drawing.Color.White
         Me.grdVariables.ColumnHeaderContextMenuStrip = Nothing
-        Me.grdVariables.Dock = System.Windows.Forms.DockStyle.Fill
         Me.grdVariables.LeadHeaderContextMenuStrip = Nothing
-        Me.grdVariables.Location = New System.Drawing.Point(0, 0)
+        Me.grdVariables.Location = New System.Drawing.Point(0, 20)
         Me.grdVariables.Name = "grdVariables"
         Me.grdVariables.RowHeaderContextMenuStrip = Nothing
         Me.grdVariables.Script = Nothing
@@ -39,14 +42,28 @@ Partial Class ucrColumnMetadata
         Me.grdVariables.SheetTabNewButtonVisible = True
         Me.grdVariables.SheetTabVisible = True
         Me.grdVariables.SheetTabWidth = 200
-        Me.grdVariables.Size = New System.Drawing.Size(344, 138)
+        Me.grdVariables.Size = New System.Drawing.Size(344, 118)
         Me.grdVariables.TabIndex = 2
         Me.grdVariables.Text = "Variables"
+        '
+        'lblHeader
+        '
+        Me.lblHeader.BackColor = System.Drawing.Color.Green
+        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeader.Location = New System.Drawing.Point(0, 0)
+        Me.lblHeader.Name = "lblHeader"
+        Me.lblHeader.Size = New System.Drawing.Size(344, 20)
+        Me.lblHeader.TabIndex = 6
+        Me.lblHeader.Text = "Column Metadata"
+        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'ucrColumnMetadata
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblHeader)
         Me.Controls.Add(Me.grdVariables)
         Me.Name = "ucrColumnMetadata"
         Me.Size = New System.Drawing.Size(344, 138)
@@ -55,4 +72,5 @@ Partial Class ucrColumnMetadata
     End Sub
 
     Friend WithEvents grdVariables As unvell.ReoGrid.ReoGridControl
+    Friend WithEvents lblHeader As Label
 End Class

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -38,19 +38,18 @@ Partial Class ucrColumnMetadata
         Me.grdVariables.SheetTabContextMenuStrip = Nothing
         Me.grdVariables.SheetTabNewButtonVisible = True
         Me.grdVariables.SheetTabVisible = True
-        Me.grdVariables.SheetTabWidth = 300
+        Me.grdVariables.SheetTabWidth = 200
         Me.grdVariables.Size = New System.Drawing.Size(344, 138)
         Me.grdVariables.TabIndex = 2
         Me.grdVariables.Text = "Variables"
         '
-        'frmVariables
+        'ucrColumnMetadata
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(344, 138)
         Me.Controls.Add(Me.grdVariables)
-        Me.Name = "ucrVariables"
-        Me.Text = "Column Metadata"
+        Me.Name = "ucrColumnMetadata"
+        Me.Size = New System.Drawing.Size(344, 138)
         Me.ResumeLayout(False)
 
     End Sub

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -49,7 +49,7 @@ Partial Class ucrColumnMetadata
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(344, 138)
         Me.Controls.Add(Me.grdVariables)
-        Me.Name = "frmVariables"
+        Me.Name = "ucrVariables"
         Me.Text = "Column Metadata"
         Me.ResumeLayout(False)
 

--- a/instat/ucrColumnMetadata.Designer.vb
+++ b/instat/ucrColumnMetadata.Designer.vb
@@ -1,0 +1,59 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrColumnMetadata
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.grdVariables = New unvell.ReoGrid.ReoGridControl()
+        Me.SuspendLayout()
+        '
+        'grdVariables
+        '
+        Me.grdVariables.BackColor = System.Drawing.Color.White
+        Me.grdVariables.ColumnHeaderContextMenuStrip = Nothing
+        Me.grdVariables.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.grdVariables.LeadHeaderContextMenuStrip = Nothing
+        Me.grdVariables.Location = New System.Drawing.Point(0, 0)
+        Me.grdVariables.Name = "grdVariables"
+        Me.grdVariables.RowHeaderContextMenuStrip = Nothing
+        Me.grdVariables.Script = Nothing
+        Me.grdVariables.SheetTabContextMenuStrip = Nothing
+        Me.grdVariables.SheetTabNewButtonVisible = True
+        Me.grdVariables.SheetTabVisible = True
+        Me.grdVariables.SheetTabWidth = 300
+        Me.grdVariables.Size = New System.Drawing.Size(344, 138)
+        Me.grdVariables.TabIndex = 2
+        Me.grdVariables.Text = "Variables"
+        '
+        'frmVariables
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(344, 138)
+        Me.Controls.Add(Me.grdVariables)
+        Me.Name = "frmVariables"
+        Me.Text = "Column Metadata"
+        Me.ResumeLayout(False)
+
+    End Sub
+
+    Friend WithEvents grdVariables As unvell.ReoGrid.ReoGridControl
+End Class

--- a/instat/ucrColumnMetadata.resx
+++ b/instat/ucrColumnMetadata.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -23,7 +23,6 @@ Public Class ucrColumnMetadata
 
     Private Sub frmVariables_Load(sender As Object, e As EventArgs) Handles Me.Load
         loadForm()
-        frmMain.clsGrids.SetVariablesMetadata(grdVariables)
     End Sub
 
     Private Sub loadForm()
@@ -106,4 +105,17 @@ Public Class ucrColumnMetadata
         e.IsCancelled = True
     End Sub
 
+    Public Sub CopyRange()
+        Try
+            grdVariables.CurrentWorksheet.Copy()
+        Catch
+            MessageBox.Show("Cannot copy the current selection.")
+        End Try
+    End Sub
+
+    Public Sub SelectAllText()
+        If grdCurrSheet IsNot Nothing Then
+            grdCurrSheet.SelectAll()
+        End If
+    End Sub
 End Class

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -1,0 +1,109 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Imports instat.Translations
+Imports unvell.ReoGrid.Events
+
+Public Class ucrColumnMetadata
+    'Public context As New frmEditor
+    Public WithEvents grdCurrSheet As unvell.ReoGrid.Worksheet
+    Public strPreviousCellText As String
+
+    Private Sub frmVariables_Load(sender As Object, e As EventArgs) Handles Me.Load
+        loadForm()
+        frmMain.clsGrids.SetVariablesMetadata(grdVariables)
+    End Sub
+
+    Private Sub loadForm()
+        grdVariables.CurrentWorksheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_Readonly, True)
+        'gridVariables.SheetTabNewButtonVisible = False
+        'gridVariables.SheetTabControlNewButtonVisible = False
+        'grdVariables.CurrentWorksheet.Resize(5, 5)
+        'grdVariables.ColumnHeaderContextMenuStrip = context.grdData.ColumnHeaderContextMenuStrip
+        'grdVariables.RowHeaderContextMenuStrip = context.grdData.RowHeaderContextMenuStrip
+        'grdVariables.ContextMenuStrip = context.grdData.ContextMenuStrip
+        'autoTranslate(Me)
+    End Sub
+
+    Private Sub grdVariables_CurrentWorksheetChanged(sender As Object, e As EventArgs) Handles grdVariables.CurrentWorksheetChanged, Me.Load, grdVariables.WorksheetInserted
+        grdCurrSheet = grdVariables.CurrentWorksheet
+        grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
+        grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_Readonly, True)
+        grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
+        grdCurrSheet.SelectionForwardDirection = unvell.ReoGrid.SelectionForwardDirection.Down
+    End Sub
+
+    Private Sub grdCurrSheet_AfterCellEdit(sender As Object, e As CellAfterEditEventArgs) Handles grdCurrSheet.AfterCellEdit
+        Dim strScript As String = ""
+        Dim strComment As String = ""
+        Dim strDecimalLabel As String = "DisplayDecimal"
+        Dim strNameLabel As String = "Name"
+        Dim strDataTypeLabel As String = "DataType"
+        Dim strColumn = grdCurrSheet(e.Cell.Row, 0).ToString()
+        Dim bRunScript As Boolean = False
+
+        If grdCurrSheet.ColumnHeaders(e.Cell.Column).Text = strNameLabel Then
+            strScript = frmMain.clsRLink.strInstatDataObject & "$rename_column_in_data(data_name =" & Chr(34) & grdCurrSheet.Name & Chr(34) & ",column_name = " & Chr(34) & strPreviousCellText & Chr(34) & ",new_val=" & Chr(34) & e.NewData & Chr(34) & ")"
+            strComment = "Renamed column"
+            bRunScript = True
+        ElseIf grdCurrSheet.ColumnHeaders(e.Cell.Column).Text = strDataTypeLabel Then
+            If e.NewData.ToString() <> "factor" AndAlso e.NewData.ToString() <> "numeric" AndAlso e.NewData.ToString() <> "character" Then
+                e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+            Else
+                strScript = frmMain.clsRLink.strInstatDataObject & "$convert_column_to_type(data_name =" & Chr(34) & grdCurrSheet.Name & Chr(34) & ",col_names = " & Chr(34) & strColumn & Chr(34) & ",to_type=" & Chr(34) & e.NewData & Chr(34) & ")"
+                strComment = "Converted column type"
+                bRunScript = True
+            End If
+        ElseIf grdCurrSheet.ColumnHeaders(e.Cell.Column).Text = strDecimalLabel Then
+            If Integer.TryParse(e.NewData, 0) AndAlso e.NewData >= 0 Then
+                strScript = frmMain.clsRLink.strInstatDataObject & "$append_to_variables_metadata(data_name =" & Chr(34) & grdCurrSheet.Name & Chr(34) & ",col_names = " & Chr(34) & strColumn & Chr(34) & ",property=" & Chr(34) & strDecimalLabel & Chr(34) & ",new_val=" & e.NewData & ")"
+                strComment = "Edited variables metadata value"
+                bRunScript = True
+            Else
+                e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+            End If
+        End If
+        Try
+            frmMain.clsRLink.RunScript(strScript, strComment:=strComment)
+        Catch
+            e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+        End Try
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCellEdit(sender As Object, e As CellBeforeEditEventArgs) Handles grdCurrSheet.BeforeCellEdit
+        strPreviousCellText = e.Cell.Data.ToString()
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCut(sender As Object, e As BeforeRangeOperationEventArgs) Handles grdCurrSheet.BeforeCut
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_BeforePaste(sender As Object, e As BeforeRangeOperationEventArgs) Handles grdCurrSheet.BeforePaste
+        MsgBox("Pasting multiple cells is currently disabled. This feature will be included in future versions.", MsgBoxStyle.Information, "Cannot paste")
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCellKeyDown(sender As Object, e As BeforeCellKeyDownEventArgs) Handles grdCurrSheet.BeforeCellKeyDown
+        If e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Delete OrElse e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Back Then
+            MsgBox("Deleting cells is currently disabled. This feature will be included in future versions.", MsgBoxStyle.Information, "Cannot delete cells.")
+            e.IsCancelled = True
+        End If
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeRangeMove(sender As Object, e As BeforeCopyOrMoveRangeEventArgs) Handles grdCurrSheet.BeforeRangeMove
+        e.IsCancelled = True
+    End Sub
+
+End Class

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -27,8 +27,8 @@ Public Class ucrColumnMetadata
 
     Private Sub loadForm()
         grdVariables.CurrentWorksheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_Readonly, True)
-        'gridVariables.SheetTabNewButtonVisible = False
-        'gridVariables.SheetTabControlNewButtonVisible = False
+        grdVariables.SheetTabNewButtonVisible = False
+        grdVariables.SheetTabWidth = 250
         'grdVariables.CurrentWorksheet.Resize(5, 5)
         'grdVariables.ColumnHeaderContextMenuStrip = context.grdData.ColumnHeaderContextMenuStrip
         'grdVariables.RowHeaderContextMenuStrip = context.grdData.RowHeaderContextMenuStrip

--- a/instat/ucrDataFrameMetadata.Designer.vb
+++ b/instat/ucrDataFrameMetadata.Designer.vb
@@ -24,15 +24,18 @@ Partial Class ucrDataFrameMetadata
     Private Sub InitializeComponent()
         Me.grdMetaData = New unvell.ReoGrid.ReoGridControl()
         Me.txtMetadata = New System.Windows.Forms.TextBox()
+        Me.lblHeader = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'grdMetaData
         '
+        Me.grdMetaData.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.grdMetaData.BackColor = System.Drawing.Color.White
         Me.grdMetaData.ColumnHeaderContextMenuStrip = Nothing
-        Me.grdMetaData.Dock = System.Windows.Forms.DockStyle.Fill
         Me.grdMetaData.LeadHeaderContextMenuStrip = Nothing
-        Me.grdMetaData.Location = New System.Drawing.Point(0, 0)
+        Me.grdMetaData.Location = New System.Drawing.Point(0, 20)
         Me.grdMetaData.Name = "grdMetaData"
         Me.grdMetaData.RowHeaderContextMenuStrip = Nothing
         Me.grdMetaData.Script = Nothing
@@ -40,7 +43,7 @@ Partial Class ucrDataFrameMetadata
         Me.grdMetaData.SheetTabNewButtonVisible = False
         Me.grdMetaData.SheetTabVisible = False
         Me.grdMetaData.SheetTabWidth = 100
-        Me.grdMetaData.Size = New System.Drawing.Size(477, 317)
+        Me.grdMetaData.Size = New System.Drawing.Size(477, 297)
         Me.grdMetaData.TabIndex = 1
         Me.grdMetaData.Text = "Meta Data"
         '
@@ -53,15 +56,28 @@ Partial Class ucrDataFrameMetadata
         Me.txtMetadata.Size = New System.Drawing.Size(205, 100)
         Me.txtMetadata.TabIndex = 2
         '
-        'frmMetaData
+        'lblHeader
+        '
+        Me.lblHeader.BackColor = System.Drawing.Color.Green
+        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeader.Location = New System.Drawing.Point(0, 0)
+        Me.lblHeader.Name = "lblHeader"
+        Me.lblHeader.Size = New System.Drawing.Size(477, 20)
+        Me.lblHeader.TabIndex = 7
+        Me.lblHeader.Text = "Data Frame Metadata"
+        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'ucrDataFrameMetadata
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(477, 317)
+        Me.Controls.Add(Me.lblHeader)
         Me.Controls.Add(Me.grdMetaData)
         Me.Controls.Add(Me.txtMetadata)
-        Me.Name = "ucrMetaData"
-        Me.Text = "Data frame Metadata"
+        Me.Name = "ucrDataFrameMetadata"
+        Me.Size = New System.Drawing.Size(477, 317)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -69,4 +85,5 @@ Partial Class ucrDataFrameMetadata
 
     Friend WithEvents grdMetaData As unvell.ReoGrid.ReoGridControl
     Friend WithEvents txtMetadata As TextBox
+    Friend WithEvents lblHeader As Label
 End Class

--- a/instat/ucrDataFrameMetadata.Designer.vb
+++ b/instat/ucrDataFrameMetadata.Designer.vb
@@ -1,0 +1,72 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrDataFrameMetadata
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.grdMetaData = New unvell.ReoGrid.ReoGridControl()
+        Me.txtMetadata = New System.Windows.Forms.TextBox()
+        Me.SuspendLayout()
+        '
+        'grdMetaData
+        '
+        Me.grdMetaData.BackColor = System.Drawing.Color.White
+        Me.grdMetaData.ColumnHeaderContextMenuStrip = Nothing
+        Me.grdMetaData.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.grdMetaData.LeadHeaderContextMenuStrip = Nothing
+        Me.grdMetaData.Location = New System.Drawing.Point(0, 0)
+        Me.grdMetaData.Name = "grdMetaData"
+        Me.grdMetaData.RowHeaderContextMenuStrip = Nothing
+        Me.grdMetaData.Script = Nothing
+        Me.grdMetaData.SheetTabContextMenuStrip = Nothing
+        Me.grdMetaData.SheetTabNewButtonVisible = False
+        Me.grdMetaData.SheetTabVisible = False
+        Me.grdMetaData.SheetTabWidth = 100
+        Me.grdMetaData.Size = New System.Drawing.Size(477, 317)
+        Me.grdMetaData.TabIndex = 1
+        Me.grdMetaData.Text = "Meta Data"
+        '
+        'txtMetadata
+        '
+        Me.txtMetadata.Location = New System.Drawing.Point(213, 11)
+        Me.txtMetadata.Multiline = True
+        Me.txtMetadata.Name = "txtMetadata"
+        Me.txtMetadata.ReadOnly = True
+        Me.txtMetadata.Size = New System.Drawing.Size(205, 100)
+        Me.txtMetadata.TabIndex = 2
+        '
+        'frmMetaData
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(477, 317)
+        Me.Controls.Add(Me.grdMetaData)
+        Me.Controls.Add(Me.txtMetadata)
+        Me.Name = "ucrMetaData"
+        Me.Text = "Data frame Metadata"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents grdMetaData As unvell.ReoGrid.ReoGridControl
+    Friend WithEvents txtMetadata As TextBox
+End Class

--- a/instat/ucrDataFrameMetadata.resx
+++ b/instat/ucrDataFrameMetadata.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/ucrDataFrameMetadata.vb
+++ b/instat/ucrDataFrameMetadata.vb
@@ -1,0 +1,108 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Imports instat.Translations
+Imports unvell.ReoGrid.Events
+
+Public Class ucrDataFrameMetadata
+    Public WithEvents grdCurrSheet As unvell.ReoGrid.Worksheet
+    Public strPreviousCellText As String
+
+    Private Sub frmMetaData_Load(sender As Object, e As EventArgs) Handles Me.Load
+        grdMetaData.Worksheets(0).Name = "metadata"
+        frmMain.clsGrids.SetMetadata(grdMetaData)
+        loadForm()
+    End Sub
+
+    ' TODO this needs tidying up
+    Private Sub loadForm()
+        grdMetaData.SetSettings(unvell.ReoGrid.WorkbookSettings.View_ShowSheetTabControl, False)
+        grdMetaData.SetSettings(unvell.ReoGrid.WorkbookSettings.View_ShowHorScroll, False)
+        grdMetaData.SheetTabNewButtonVisible = False
+        'grdMetaData.ColumnHeaderContextMenuStrip = context.grdData.ColumnHeaderContextMenuStrip
+        'grdMetaData.ContextMenuStrip = context.grdData.ContextMenuStrip
+        'grdMetaData.RowHeaderContextMenuStrip = context.grdData.RowHeaderContextMenuStrip
+    End Sub
+
+    Private Sub grdMetaData_CurrentWorksheetChanged(sender As Object, e As EventArgs) Handles grdMetaData.CurrentWorksheetChanged, Me.Load, grdMetaData.WorksheetInserted
+        grdCurrSheet = grdMetaData.CurrentWorksheet
+        grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
+        grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_Readonly, True)
+        grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
+        grdCurrSheet.SelectionForwardDirection = unvell.ReoGrid.SelectionForwardDirection.Down
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCellEdit(sender As Object, e As CellBeforeEditEventArgs) Handles grdCurrSheet.BeforeCellEdit
+        'strPreviousCellText = e.Cell.Data.ToString()
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_AfterCellEdit(sender As Object, e As CellAfterEditEventArgs) Handles grdCurrSheet.AfterCellEdit
+        Dim strScript As String = ""
+        Dim strComment As String = ""
+        Dim bRunScript As Boolean = False
+
+        If e.Cell.Column = 0 Then
+            'TODO fix bug with this not updating grid correctly after renaming
+            'strScript = frmMain.clsRLink.strInstatDataObject & "$rename_dataframe(data_name =" & Chr(34) & strPreviousCellText & Chr(34) & ", new_val = " & Chr(34) & e.NewData & Chr(34) & ")"
+            'strComment = "Renamed sheet"
+        Else
+            strScript = frmMain.clsRLink.strInstatDataObject & "$append_to_dataframe_metadata(data_name =" & Chr(34) & grdCurrSheet(e.Cell.Row, 0).ToString() & Chr(34) & ", property = " & Chr(34) & grdCurrSheet.ColumnHeaders(e.Cell.Column).Text & "new_value = " & Chr(34) & e.NewData & Chr(34) & ")"
+            strComment = "Changed metadata value"
+            bRunScript = True
+        End If
+        If bRunScript Then
+            Try
+                frmMain.clsRLink.RunScript(strScript, strComment:=strComment)
+            Catch
+                e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+            End Try
+        End If
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCut(sender As Object, e As BeforeRangeOperationEventArgs) Handles grdCurrSheet.BeforeCut
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_BeforePaste(sender As Object, e As BeforeRangeOperationEventArgs) Handles grdCurrSheet.BeforePaste
+        MsgBox("Pasting multiple cells is currently disabled. This feature will be included in future versions.", MsgBoxStyle.Information, "Cannot paste")
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCellKeyDown(sender As Object, e As BeforeCellKeyDownEventArgs) Handles grdCurrSheet.BeforeCellKeyDown
+        If e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Delete OrElse e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Back Then
+            MsgBox("Deleting cells is currently disabled. This feature will be included in future versions.", MsgBoxStyle.Information, "Cannot delete cells.")
+            e.IsCancelled = True
+        End If
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeRangeMove(sender As Object, e As BeforeCopyOrMoveRangeEventArgs) Handles grdCurrSheet.BeforeRangeMove
+        e.IsCancelled = True
+    End Sub
+
+    Public Sub CopyRange()
+        Try
+            grdMetaData.CurrentWorksheet.Copy()
+        Catch
+            MessageBox.Show("Cannot copy the current selection.")
+        End Try
+    End Sub
+
+    Public Sub SelectAllText()
+        If grdCurrSheet IsNot Nothing Then
+            grdCurrSheet.SelectAll()
+        End If
+    End Sub
+End Class

--- a/instat/ucrDataView.Designer.vb
+++ b/instat/ucrDataView.Designer.vb
@@ -1,0 +1,477 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrDataView
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
+        Me.grdData = New unvell.ReoGrid.ReoGridControl()
+        Me.columnContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.mnuColumnRename = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDuplicateColumn = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuInsertColsBefore = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuInsertColsAfter = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDeleteCol = New System.Windows.Forms.ToolStripMenuItem()
+        Me.toolStripMenuItem2 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuConvertToFactor = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuCovertToOrderedFactors = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuConvertText = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuConvertVariate = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuConvertToDate = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuConvert = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuHideColumns = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuUnhideColumns = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuUnhideAllColumns = New System.Windows.Forms.ToolStripMenuItem()
+        Me.toolStripMenuItem21 = New System.Windows.Forms.ToolStripSeparator()
+        Me.FreezeToHereToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.UnfreezeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
+        Me.SortToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.columnFilterToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.clearColumnFilterToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cellContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.AddComment = New System.Windows.Forms.ToolStripMenuItem()
+        Me.cutRangeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.copyRangeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.pasteRangeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.rowContextMenuStrip = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.mnuInsertRowsBefore = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuInsertRowsAfter = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDeleteRows = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuAddComment = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator4 = New System.Windows.Forms.ToolStripSeparator()
+        Me.mnuFilter = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuRemoveCurrentFilter = New System.Windows.Forms.ToolStripMenuItem()
+        Me.statusColumnMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.insertSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.deleteSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.renameSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.reorderSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CopySheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.HideSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.unhideSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ViewSheet = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblNoData = New System.Windows.Forms.Label()
+        Me.lblRowDisplay = New System.Windows.Forms.Label()
+        Me.columnContextMenuStrip.SuspendLayout()
+        Me.cellContextMenuStrip.SuspendLayout()
+        Me.rowContextMenuStrip.SuspendLayout()
+        Me.statusColumnMenu.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'grdData
+        '
+        Me.grdData.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.grdData.BackColor = System.Drawing.Color.White
+        Me.grdData.ColumnHeaderContextMenuStrip = Me.columnContextMenuStrip
+        Me.grdData.ContextMenuStrip = Me.cellContextMenuStrip
+        Me.grdData.LeadHeaderContextMenuStrip = Nothing
+        Me.grdData.Location = New System.Drawing.Point(0, 0)
+        Me.grdData.Name = "grdData"
+        Me.grdData.RowHeaderContextMenuStrip = Me.rowContextMenuStrip
+        Me.grdData.Script = Nothing
+        Me.grdData.SheetTabContextMenuStrip = Me.statusColumnMenu
+        Me.grdData.SheetTabNewButtonVisible = False
+        Me.grdData.SheetTabVisible = True
+        Me.grdData.SheetTabWidth = 200
+        Me.grdData.Size = New System.Drawing.Size(441, 261)
+        Me.grdData.TabIndex = 0
+        '
+        'columnContextMenuStrip
+        '
+        Me.columnContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuColumnRename, Me.mnuDuplicateColumn, Me.mnuInsertColsBefore, Me.mnuInsertColsAfter, Me.mnuDeleteCol, Me.toolStripMenuItem2, Me.mnuConvertToFactor, Me.mnuCovertToOrderedFactors, Me.mnuConvertText, Me.mnuConvertVariate, Me.mnuConvertToDate, Me.mnuConvert, Me.ToolStripSeparator1, Me.mnuHideColumns, Me.mnuUnhideColumns, Me.mnuUnhideAllColumns, Me.toolStripMenuItem21, Me.FreezeToHereToolStripMenuItem, Me.UnfreezeToolStripMenuItem, Me.ToolStripSeparator3, Me.SortToolStripMenuItem, Me.columnFilterToolStripMenuItem, Me.clearColumnFilterToolStripMenuItem})
+        Me.columnContextMenuStrip.Name = "columnContextMenuStrip"
+        Me.columnContextMenuStrip.Size = New System.Drawing.Size(213, 446)
+        '
+        'mnuColumnRename
+        '
+        Me.mnuColumnRename.Name = "mnuColumnRename"
+        Me.mnuColumnRename.Size = New System.Drawing.Size(212, 22)
+        Me.mnuColumnRename.Text = "Rename Column..."
+        '
+        'mnuDuplicateColumn
+        '
+        Me.mnuDuplicateColumn.Name = "mnuDuplicateColumn"
+        Me.mnuDuplicateColumn.Size = New System.Drawing.Size(212, 22)
+        Me.mnuDuplicateColumn.Text = "Duplicate Column..."
+        '
+        'mnuInsertColsBefore
+        '
+        Me.mnuInsertColsBefore.Name = "mnuInsertColsBefore"
+        Me.mnuInsertColsBefore.Size = New System.Drawing.Size(212, 22)
+        Me.mnuInsertColsBefore.Text = "Insert Column(s) Before"
+        '
+        'mnuInsertColsAfter
+        '
+        Me.mnuInsertColsAfter.Name = "mnuInsertColsAfter"
+        Me.mnuInsertColsAfter.Size = New System.Drawing.Size(212, 22)
+        Me.mnuInsertColsAfter.Text = "Insert Column(s) After"
+        '
+        'mnuDeleteCol
+        '
+        Me.mnuDeleteCol.Name = "mnuDeleteCol"
+        Me.mnuDeleteCol.Size = New System.Drawing.Size(212, 22)
+        Me.mnuDeleteCol.Text = "Delete Column(s)"
+        '
+        'toolStripMenuItem2
+        '
+        Me.toolStripMenuItem2.Name = "toolStripMenuItem2"
+        Me.toolStripMenuItem2.Size = New System.Drawing.Size(209, 6)
+        '
+        'mnuConvertToFactor
+        '
+        Me.mnuConvertToFactor.Name = "mnuConvertToFactor"
+        Me.mnuConvertToFactor.Size = New System.Drawing.Size(212, 22)
+        Me.mnuConvertToFactor.Text = "Convert to Factor"
+        '
+        'mnuCovertToOrderedFactors
+        '
+        Me.mnuCovertToOrderedFactors.Name = "mnuCovertToOrderedFactors"
+        Me.mnuCovertToOrderedFactors.Size = New System.Drawing.Size(212, 22)
+        Me.mnuCovertToOrderedFactors.Text = "Convert to Ordered Factor"
+        '
+        'mnuConvertText
+        '
+        Me.mnuConvertText.Name = "mnuConvertText"
+        Me.mnuConvertText.Size = New System.Drawing.Size(212, 22)
+        Me.mnuConvertText.Text = "Convert to Character"
+        '
+        'mnuConvertVariate
+        '
+        Me.mnuConvertVariate.Name = "mnuConvertVariate"
+        Me.mnuConvertVariate.Size = New System.Drawing.Size(212, 22)
+        Me.mnuConvertVariate.Text = "Convert to Numeric"
+        '
+        'mnuConvertToDate
+        '
+        Me.mnuConvertToDate.Name = "mnuConvertToDate"
+        Me.mnuConvertToDate.Size = New System.Drawing.Size(212, 22)
+        Me.mnuConvertToDate.Text = "Convert to Date..."
+        '
+        'mnuConvert
+        '
+        Me.mnuConvert.Name = "mnuConvert"
+        Me.mnuConvert.Size = New System.Drawing.Size(212, 22)
+        Me.mnuConvert.Text = "Convert..."
+        '
+        'ToolStripSeparator1
+        '
+        Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(209, 6)
+        '
+        'mnuHideColumns
+        '
+        Me.mnuHideColumns.Name = "mnuHideColumns"
+        Me.mnuHideColumns.Size = New System.Drawing.Size(212, 22)
+        Me.mnuHideColumns.Text = "Hide"
+        '
+        'mnuUnhideColumns
+        '
+        Me.mnuUnhideColumns.Name = "mnuUnhideColumns"
+        Me.mnuUnhideColumns.Size = New System.Drawing.Size(212, 22)
+        Me.mnuUnhideColumns.Text = "Unhide..."
+        '
+        'mnuUnhideAllColumns
+        '
+        Me.mnuUnhideAllColumns.Name = "mnuUnhideAllColumns"
+        Me.mnuUnhideAllColumns.Size = New System.Drawing.Size(212, 22)
+        Me.mnuUnhideAllColumns.Tag = "Unhide_All"
+        Me.mnuUnhideAllColumns.Text = "Unhide All"
+        '
+        'toolStripMenuItem21
+        '
+        Me.toolStripMenuItem21.Name = "toolStripMenuItem21"
+        Me.toolStripMenuItem21.Size = New System.Drawing.Size(209, 6)
+        '
+        'FreezeToHereToolStripMenuItem
+        '
+        Me.FreezeToHereToolStripMenuItem.Name = "FreezeToHereToolStripMenuItem"
+        Me.FreezeToHereToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.FreezeToHereToolStripMenuItem.Text = "Freeze to Here"
+        '
+        'UnfreezeToolStripMenuItem
+        '
+        Me.UnfreezeToolStripMenuItem.Name = "UnfreezeToolStripMenuItem"
+        Me.UnfreezeToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.UnfreezeToolStripMenuItem.Text = "Unfreeze"
+        '
+        'ToolStripSeparator3
+        '
+        Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
+        Me.ToolStripSeparator3.Size = New System.Drawing.Size(209, 6)
+        '
+        'SortToolStripMenuItem
+        '
+        Me.SortToolStripMenuItem.Name = "SortToolStripMenuItem"
+        Me.SortToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.SortToolStripMenuItem.Text = "Sort..."
+        '
+        'columnFilterToolStripMenuItem
+        '
+        Me.columnFilterToolStripMenuItem.Name = "columnFilterToolStripMenuItem"
+        Me.columnFilterToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.columnFilterToolStripMenuItem.Text = "Filter..."
+        '
+        'clearColumnFilterToolStripMenuItem
+        '
+        Me.clearColumnFilterToolStripMenuItem.Name = "clearColumnFilterToolStripMenuItem"
+        Me.clearColumnFilterToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.clearColumnFilterToolStripMenuItem.Text = "Remove Current Filter"
+        '
+        'cellContextMenuStrip
+        '
+        Me.cellContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AddComment, Me.cutRangeToolStripMenuItem, Me.copyRangeToolStripMenuItem, Me.pasteRangeToolStripMenuItem})
+        Me.cellContextMenuStrip.Name = "cellContextMenuStrip"
+        Me.cellContextMenuStrip.Size = New System.Drawing.Size(163, 92)
+        '
+        'AddComment
+        '
+        Me.AddComment.Name = "AddComment"
+        Me.AddComment.Size = New System.Drawing.Size(162, 22)
+        Me.AddComment.Text = "Add Comment..."
+        '
+        'cutRangeToolStripMenuItem
+        '
+        Me.cutRangeToolStripMenuItem.Enabled = False
+        Me.cutRangeToolStripMenuItem.Name = "cutRangeToolStripMenuItem"
+        Me.cutRangeToolStripMenuItem.Size = New System.Drawing.Size(162, 22)
+        Me.cutRangeToolStripMenuItem.Text = "Cut"
+        '
+        'copyRangeToolStripMenuItem
+        '
+        Me.copyRangeToolStripMenuItem.Name = "copyRangeToolStripMenuItem"
+        Me.copyRangeToolStripMenuItem.Size = New System.Drawing.Size(162, 22)
+        Me.copyRangeToolStripMenuItem.Text = "Copy"
+        '
+        'pasteRangeToolStripMenuItem
+        '
+        Me.pasteRangeToolStripMenuItem.Enabled = False
+        Me.pasteRangeToolStripMenuItem.Name = "pasteRangeToolStripMenuItem"
+        Me.pasteRangeToolStripMenuItem.Size = New System.Drawing.Size(162, 22)
+        Me.pasteRangeToolStripMenuItem.Text = "Paste"
+        '
+        'rowContextMenuStrip
+        '
+        Me.rowContextMenuStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuInsertRowsBefore, Me.mnuInsertRowsAfter, Me.mnuDeleteRows, Me.ToolStripSeparator2, Me.mnuAddComment, Me.ToolStripSeparator4, Me.mnuFilter, Me.mnuRemoveCurrentFilter})
+        Me.rowContextMenuStrip.Name = "columnContextMenuStrip"
+        Me.rowContextMenuStrip.Size = New System.Drawing.Size(190, 148)
+        '
+        'mnuInsertRowsBefore
+        '
+        Me.mnuInsertRowsBefore.Name = "mnuInsertRowsBefore"
+        Me.mnuInsertRowsBefore.Size = New System.Drawing.Size(189, 22)
+        Me.mnuInsertRowsBefore.Text = "Insert Row(s) Before"
+        '
+        'mnuInsertRowsAfter
+        '
+        Me.mnuInsertRowsAfter.Name = "mnuInsertRowsAfter"
+        Me.mnuInsertRowsAfter.Size = New System.Drawing.Size(189, 22)
+        Me.mnuInsertRowsAfter.Text = "Insert Row(s) After"
+        '
+        'mnuDeleteRows
+        '
+        Me.mnuDeleteRows.Name = "mnuDeleteRows"
+        Me.mnuDeleteRows.Size = New System.Drawing.Size(189, 22)
+        Me.mnuDeleteRows.Text = "Delete Row(s)"
+        '
+        'ToolStripSeparator2
+        '
+        Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(186, 6)
+        '
+        'mnuAddComment
+        '
+        Me.mnuAddComment.Name = "mnuAddComment"
+        Me.mnuAddComment.Size = New System.Drawing.Size(189, 22)
+        Me.mnuAddComment.Text = "Add Comment..."
+        '
+        'ToolStripSeparator4
+        '
+        Me.ToolStripSeparator4.Name = "ToolStripSeparator4"
+        Me.ToolStripSeparator4.Size = New System.Drawing.Size(186, 6)
+        '
+        'mnuFilter
+        '
+        Me.mnuFilter.Name = "mnuFilter"
+        Me.mnuFilter.Size = New System.Drawing.Size(189, 22)
+        Me.mnuFilter.Tag = "Filter..."
+        Me.mnuFilter.Text = "Filter..."
+        '
+        'mnuRemoveCurrentFilter
+        '
+        Me.mnuRemoveCurrentFilter.Name = "mnuRemoveCurrentFilter"
+        Me.mnuRemoveCurrentFilter.Size = New System.Drawing.Size(189, 22)
+        Me.mnuRemoveCurrentFilter.Tag = "Remove_Current_Filter"
+        Me.mnuRemoveCurrentFilter.Text = "Remove Current Filter"
+        '
+        'statusColumnMenu
+        '
+        Me.statusColumnMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.insertSheet, Me.deleteSheet, Me.renameSheet, Me.reorderSheet, Me.CopySheet, Me.HideSheet, Me.unhideSheet, Me.ViewSheet})
+        Me.statusColumnMenu.Name = "statusColumnMenu"
+        Me.statusColumnMenu.Size = New System.Drawing.Size(163, 180)
+        '
+        'insertSheet
+        '
+        Me.insertSheet.Name = "insertSheet"
+        Me.insertSheet.Size = New System.Drawing.Size(162, 22)
+        Me.insertSheet.Text = "Insert..."
+        '
+        'deleteSheet
+        '
+        Me.deleteSheet.Name = "deleteSheet"
+        Me.deleteSheet.Size = New System.Drawing.Size(162, 22)
+        Me.deleteSheet.Text = "Delete"
+        '
+        'renameSheet
+        '
+        Me.renameSheet.Name = "renameSheet"
+        Me.renameSheet.Size = New System.Drawing.Size(162, 22)
+        Me.renameSheet.Text = "Rename..."
+        '
+        'reorderSheet
+        '
+        Me.reorderSheet.Enabled = False
+        Me.reorderSheet.Name = "reorderSheet"
+        Me.reorderSheet.Size = New System.Drawing.Size(162, 22)
+        Me.reorderSheet.Text = "Reorder..."
+        '
+        'CopySheet
+        '
+        Me.CopySheet.Name = "CopySheet"
+        Me.CopySheet.Size = New System.Drawing.Size(162, 22)
+        Me.CopySheet.Text = "Copy..."
+        '
+        'HideSheet
+        '
+        Me.HideSheet.Enabled = False
+        Me.HideSheet.Name = "HideSheet"
+        Me.HideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.HideSheet.Text = "Hide"
+        '
+        'unhideSheet
+        '
+        Me.unhideSheet.Enabled = False
+        Me.unhideSheet.Name = "unhideSheet"
+        Me.unhideSheet.Size = New System.Drawing.Size(162, 22)
+        Me.unhideSheet.Text = "Unhide"
+        '
+        'ViewSheet
+        '
+        Me.ViewSheet.Name = "ViewSheet"
+        Me.ViewSheet.Size = New System.Drawing.Size(162, 22)
+        Me.ViewSheet.Text = "View Data Frame"
+        '
+        'lblNoData
+        '
+        Me.lblNoData.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblNoData.Font = New System.Drawing.Font("Microsoft Sans Serif", 20.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblNoData.Location = New System.Drawing.Point(0, 0)
+        Me.lblNoData.Name = "lblNoData"
+        Me.lblNoData.Size = New System.Drawing.Size(444, 284)
+        Me.lblNoData.TabIndex = 1
+        Me.lblNoData.Tag = "no_data_loaded"
+        Me.lblNoData.Text = "No Data Loaded"
+        Me.lblNoData.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'lblRowDisplay
+        '
+        Me.lblRowDisplay.Dock = System.Windows.Forms.DockStyle.Bottom
+        Me.lblRowDisplay.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblRowDisplay.Location = New System.Drawing.Point(0, 264)
+        Me.lblRowDisplay.Name = "lblRowDisplay"
+        Me.lblRowDisplay.Size = New System.Drawing.Size(444, 20)
+        Me.lblRowDisplay.TabIndex = 4
+        Me.lblRowDisplay.Text = "Label1"
+        Me.lblRowDisplay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'ucrDataView
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblRowDisplay)
+        Me.Controls.Add(Me.grdData)
+        Me.Controls.Add(Me.lblNoData)
+        Me.Name = "ucrDataView"
+        Me.Size = New System.Drawing.Size(444, 284)
+        Me.Tag = "Data_View"
+        Me.columnContextMenuStrip.ResumeLayout(False)
+        Me.cellContextMenuStrip.ResumeLayout(False)
+        Me.rowContextMenuStrip.ResumeLayout(False)
+        Me.statusColumnMenu.ResumeLayout(False)
+        Me.ResumeLayout(False)
+
+    End Sub
+
+    Public WithEvents grdData As unvell.ReoGrid.ReoGridControl
+    Friend WithEvents lblNoData As Label
+    Private WithEvents columnContextMenuStrip As ContextMenuStrip
+    Private WithEvents mnuInsertColsBefore As ToolStripMenuItem
+    Private WithEvents mnuDeleteCol As ToolStripMenuItem
+    Private WithEvents toolStripMenuItem2 As ToolStripSeparator
+    Private WithEvents mnuHideColumns As ToolStripMenuItem
+    Private WithEvents mnuUnhideColumns As ToolStripMenuItem
+    Private WithEvents toolStripMenuItem21 As ToolStripSeparator
+    Private WithEvents columnFilterToolStripMenuItem As ToolStripMenuItem
+    Private WithEvents clearColumnFilterToolStripMenuItem As ToolStripMenuItem
+    Private WithEvents cellContextMenuStrip As ContextMenuStrip
+    Private WithEvents cutRangeToolStripMenuItem As ToolStripMenuItem
+    Private WithEvents copyRangeToolStripMenuItem As ToolStripMenuItem
+    Private WithEvents pasteRangeToolStripMenuItem As ToolStripMenuItem
+    Private WithEvents rowContextMenuStrip As ContextMenuStrip
+    Private WithEvents mnuInsertRowsAfter As ToolStripMenuItem
+    Private WithEvents mnuDeleteRows As ToolStripMenuItem
+    Friend WithEvents statusColumnMenu As ContextMenuStrip
+    Friend WithEvents insertSheet As ToolStripMenuItem
+    Friend WithEvents deleteSheet As ToolStripMenuItem
+    Friend WithEvents renameSheet As ToolStripMenuItem
+    Friend WithEvents mnuColumnRename As ToolStripMenuItem
+    Friend WithEvents mnuConvertText As ToolStripMenuItem
+    Friend WithEvents mnuConvertVariate As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator1 As ToolStripSeparator
+    Friend WithEvents mnuConvertToFactor As ToolStripMenuItem
+    Friend WithEvents CopySheet As ToolStripMenuItem
+    Friend WithEvents HideSheet As ToolStripMenuItem
+    Friend WithEvents reorderSheet As ToolStripMenuItem
+    Friend WithEvents unhideSheet As ToolStripMenuItem
+    Friend WithEvents mnuUnhideAllColumns As ToolStripMenuItem
+    Friend WithEvents mnuInsertColsAfter As ToolStripMenuItem
+    Friend WithEvents mnuInsertRowsBefore As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator2 As ToolStripSeparator
+    Friend WithEvents mnuFilter As ToolStripMenuItem
+    Friend WithEvents mnuRemoveCurrentFilter As ToolStripMenuItem
+    Friend WithEvents SortToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents FreezeToHereToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents UnfreezeToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator3 As ToolStripSeparator
+    Friend WithEvents mnuConvert As ToolStripMenuItem
+    Friend WithEvents ViewSheet As ToolStripMenuItem
+    Friend WithEvents mnuConvertToDate As ToolStripMenuItem
+    Friend WithEvents mnuCovertToOrderedFactors As ToolStripMenuItem
+    Friend WithEvents mnuDuplicateColumn As ToolStripMenuItem
+    Friend WithEvents lblRowDisplay As Label
+    Friend WithEvents mnuAddComment As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator4 As ToolStripSeparator
+    Friend WithEvents AddComment As ToolStripMenuItem
+End Class

--- a/instat/ucrDataView.Designer.vb
+++ b/instat/ucrDataView.Designer.vb
@@ -73,6 +73,7 @@ Partial Class ucrDataView
         Me.ViewSheet = New System.Windows.Forms.ToolStripMenuItem()
         Me.lblNoData = New System.Windows.Forms.Label()
         Me.lblRowDisplay = New System.Windows.Forms.Label()
+        Me.lblHeader = New System.Windows.Forms.Label()
         Me.columnContextMenuStrip.SuspendLayout()
         Me.cellContextMenuStrip.SuspendLayout()
         Me.rowContextMenuStrip.SuspendLayout()
@@ -88,7 +89,7 @@ Partial Class ucrDataView
         Me.grdData.ColumnHeaderContextMenuStrip = Me.columnContextMenuStrip
         Me.grdData.ContextMenuStrip = Me.cellContextMenuStrip
         Me.grdData.LeadHeaderContextMenuStrip = Nothing
-        Me.grdData.Location = New System.Drawing.Point(0, 0)
+        Me.grdData.Location = New System.Drawing.Point(0, 23)
         Me.grdData.Name = "grdData"
         Me.grdData.RowHeaderContextMenuStrip = Me.rowContextMenuStrip
         Me.grdData.Script = Nothing
@@ -96,7 +97,7 @@ Partial Class ucrDataView
         Me.grdData.SheetTabNewButtonVisible = False
         Me.grdData.SheetTabVisible = True
         Me.grdData.SheetTabWidth = 200
-        Me.grdData.Size = New System.Drawing.Size(441, 261)
+        Me.grdData.Size = New System.Drawing.Size(441, 238)
         Me.grdData.TabIndex = 0
         '
         'columnContextMenuStrip
@@ -406,10 +407,24 @@ Partial Class ucrDataView
         Me.lblRowDisplay.Text = "Label1"
         Me.lblRowDisplay.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
+        'lblHeader
+        '
+        Me.lblHeader.BackColor = System.Drawing.Color.Green
+        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeader.Location = New System.Drawing.Point(0, 0)
+        Me.lblHeader.Name = "lblHeader"
+        Me.lblHeader.Size = New System.Drawing.Size(444, 20)
+        Me.lblHeader.TabIndex = 5
+        Me.lblHeader.Text = "Data View"
+        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
         'ucrDataView
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.lblHeader)
         Me.Controls.Add(Me.lblRowDisplay)
         Me.Controls.Add(Me.grdData)
         Me.Controls.Add(Me.lblNoData)
@@ -474,4 +489,5 @@ Partial Class ucrDataView
     Friend WithEvents mnuAddComment As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator4 As ToolStripSeparator
     Friend WithEvents AddComment As ToolStripMenuItem
+    Friend WithEvents lblHeader As Label
 End Class

--- a/instat/ucrDataView.resx
+++ b/instat/ucrDataView.resx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="columnContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="cellContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>208, 17</value>
+  </metadata>
+  <metadata name="rowContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>377, 17</value>
+  </metadata>
+  <metadata name="statusColumnMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>548, 17</value>
+  </metadata>
+</root>

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -1,0 +1,675 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Imports RDotNet
+Imports System.IO
+Imports System.Globalization
+Imports System.Threading
+Imports instat.Translations
+Imports unvell.ReoGrid.Events
+
+Public Class ucrDataView
+    'Public clearFilter As unvell.ReoGrid.Data.AutoColumnFilter
+    Public WithEvents grdCurrSheet As unvell.ReoGrid.Worksheet
+    Private clsAppendVariablesMetaData As New RFunction
+    Private clsUnhideAllColumns As New RFunction
+    Private clsInsertColumns As New RFunction
+    Private clsColumnNames As New RFunction
+    Private clsDeleteColumns As New RFunction
+    Private clsConvertTo As New RFunction
+    Private clsInsertRows As New RFunction
+    Private clsDeleteRows As New RFunction
+    Private clsReplaceValue As New RFunction
+    Private clsRemoveFilter As New RFunction
+    Private clsFreezeColumns As New RFunction
+    Private clsUnfreezeColumns As New RFunction
+    Private clsViewDataFrame As New RFunction
+    Private clsGetDataFrame As New RFunction
+    Private clsConvertOrderedFactor As New RFunction
+    Private clsFilterApplied As New RFunction
+    Public lstColumnNames As New List(Of KeyValuePair(Of String, String()))
+
+    Private Sub ucrDataView_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        FreezeToHereToolStripMenuItem.Enabled = False
+        UnfreezeToolStripMenuItem.Enabled = False
+        grdData.Visible = False
+        'autoTranslate(Me)
+        'Disable Autoformat cell
+        'This needs to be added at the part when we are writing data to the grid, not here
+        'Needs discussion, with this the grid can show NA's
+        grdData.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_AutoFormatCell, False)
+        grdData.SheetTabWidth = 450
+        SetRFunctions()
+    End Sub
+
+    'Protected Overrides Sub OnFormClosing(ByVal e As FormClosingEventArgs)
+    '    MyBase.OnFormClosing(e)
+    '    If Not e.Cancel AndAlso e.CloseReason = CloseReason.UserClosing Then
+    '        e.Cancel = True
+    '        Me.Hide()
+    '    End If
+    'End Sub
+
+    Private Sub SetRFunctions()
+        clsAppendVariablesMetaData.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$append_to_variables_metadata")
+        clsColumnNames.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_column_names")
+        clsInsertColumns.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_columns_to_data")
+        clsDeleteColumns.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$remove_columns_in_data")
+        clsConvertTo.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$convert_column_to_type")
+        clsInsertRows.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$insert_row_in_data")
+        clsDeleteRows.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$remove_rows_in_data")
+        clsUnhideAllColumns.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$unhide_all_columns")
+        clsReplaceValue.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$replace_value_in_data")
+        clsRemoveFilter.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$remove_current_filter")
+        clsFreezeColumns.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$freeze_columns")
+        clsUnfreezeColumns.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$unfreeze_columns")
+        clsGetDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsConvertOrderedFactor.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$convert_column_to_type")
+        clsFilterApplied.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$filter_applied")
+        clsViewDataFrame.SetRCommand("View")
+        UpdateRFunctionDataFrameParameters()
+    End Sub
+
+    Private Sub mnuInsertColsBefore_Click(sender As Object, e As EventArgs) Handles mnuInsertColsBefore.Click
+        clsInsertColumns.AddParameter("adjacent_column", SelectedColumnPosition(True))
+        clsInsertColumns.AddParameter("num_cols", grdCurrSheet.SelectionRange.Cols)
+        clsInsertColumns.AddParameter("before", "TRUE")
+        'TODO This should be an option in dialog
+        clsInsertColumns.AddParameter("col_name", Chr(34) & "X" & Chr(34))
+        clsInsertColumns.AddParameter("use_col_name_as_prefix", "TRUE")
+        frmMain.clsRLink.RunScript(clsInsertColumns.ToScript(), strComment:="Right click menu: Insert Column(s) Before")
+    End Sub
+
+    Private Sub mnuInsertColsAfter_Click(sender As Object, e As EventArgs) Handles mnuInsertColsAfter.Click
+        clsInsertColumns.AddParameter("adjacent_column", SelectedColumnPosition(False))
+        clsInsertColumns.AddParameter("num_cols", grdCurrSheet.SelectionRange.Cols)
+        If frmMain.clsInstatOptions.bIncludeRDefaultParameters Then
+            clsInsertColumns.AddParameter("before", "FALSE")
+        Else
+            clsInsertColumns.RemoveParameterByName("before")
+        End If
+        'TODO This should be an option in dialog
+        'This is now the default in the R method so not needed
+        'but should be added if user wants to change from default
+        'clsInsertColumns.AddParameter("col_name", Chr(34) & "X" & Chr(34))
+        'clsInsertColumns.AddParameter("use_col_name_as_prefix", "TRUE")
+        frmMain.clsRLink.RunScript(clsInsertColumns.ToScript(), strComment:="Right click menu: Insert Column(s) After")
+    End Sub
+
+    Private Sub mnuDeleteCol_Click(sender As Object, e As EventArgs) Handles mnuDeleteCol.Click
+        Dim deleteCol = MsgBox("Are you sure you want to delete these column(s)?" & vbNewLine & "This action cannot be undone.", MessageBoxButtons.YesNo, "Delete Column")
+        If deleteCol = DialogResult.Yes Then
+            clsDeleteColumns.AddParameter("cols", SelectedColumns())
+            frmMain.clsRLink.RunScript(clsDeleteColumns.ToScript(), strComment:="Right click menu: Delete Column(s)")
+        End If
+    End Sub
+
+    'Private Sub resetToDefaultWidthToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles resetToDefaultWidthToolStripMenuItem.Click
+    '    grdData.DoAction(New unvell.ReoGrid.Actions.SetColumnsWidthAction(grdData.CurrentWorksheet.SelectionRange.Col, grdData.CurrentWorksheet.SelectionRange.Cols, unvell.ReoGrid.Worksheet.InitDefaultColumnWidth))
+    'End Sub
+
+    Private Sub mnuHideColumns_Click(sender As Object, e As EventArgs) Handles mnuHideColumns.Click
+        clsAppendVariablesMetaData.AddParameter("col_names", SelectedColumns())
+        clsAppendVariablesMetaData.AddParameter("property", "is_hidden_label")
+        clsAppendVariablesMetaData.AddParameter("new_val", "TRUE")
+        frmMain.clsRLink.RunScript(clsAppendVariablesMetaData.ToScript(), strComment:="Right click menu: Hide column(s)" & SelectedColumns())
+        'grdData.DoAction(New unvell.ReoGrid.Actions.HideColumnsAction(grdData.CurrentWorksheet.SelectionRange.Col, grdData.CurrentWorksheet.SelectionRange.Cols))
+    End Sub
+
+    Private Sub mnuUnhideColumns_Click(sender As Object, e As EventArgs) Handles mnuUnhideColumns.Click
+        dlgHideShowColumns.ShowDialog()
+        'grdData.DoAction(New unvell.ReoGrid.Actions.UnhideColumnsAction(grdData.CurrentWorksheet.SelectionRange.Col, grdData.CurrentWorksheet.SelectionRange.Cols))
+    End Sub
+
+    Private Sub mnuUnhideAllColumns_Click(sender As Object, e As EventArgs) Handles mnuUnhideAllColumns.Click
+        frmMain.clsRLink.RunScript(clsUnhideAllColumns.ToScript(), strComment:="Right click menu: Unhide all columns")
+    End Sub
+
+    'Private Sub groupColumnsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles groupColumnsToolStripMenuItem1.Click
+    '    Dim worksheet = grdData.CurrentWorksheet
+
+    '    Try
+    '        grdData.DoAction(New unvell.ReoGrid.Actions.AddOutlineAction(unvell.ReoGrid.RowOrColumn.Column, grdData.CurrentWorksheet.SelectionRange.Col, grdData.CurrentWorksheet.SelectionRange.Cols))
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineOutOfRangeException
+    '        MessageBox.Show("Outline out of available range. The last column of spreadsheet cannot be grouped into outlines.")
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineAlreadyDefinedException
+    '        MessageBox.Show("Another outline which same as selected one has already exist.")
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineIntersectedException
+    '        MessageBox.Show("The outline to be added intersects with another existing one.")
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineTooMuchException
+    '        MessageBox.Show("Level of outlines reached the maximum number of levels (10).")
+    '    End Try
+    'End Sub
+
+    'Private Sub columnFilterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles columnFilterToolStripMenuItem.Click
+    '    If clearFilter IsNot Nothing Then
+    '        clearFilter.Detach()
+    '    End If
+    '    Dim filter As New unvell.ReoGrid.Actions.CreateAutoFilterAction(grdData.CurrentWorksheet.SelectionRange)
+    '    grdData.DoAction(filter)
+    '    clearFilter = filter.AutoColumnFilter
+    'End Sub
+
+    'Private Sub clearColumnFilterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles clearColumnFilterToolStripMenuItem.Click
+    '    If clearFilter IsNot Nothing Then
+    '        clearFilter.Detach()
+    '    End If
+
+    'End Sub
+
+    'Private Sub ungroupColumnsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ungroupColumnsToolStripMenuItem1.Click
+    '    Dim removeOutlineAction = New unvell.ReoGrid.Actions.RemoveOutlineAction(unvell.ReoGrid.RowOrColumn.Column, grdData.CurrentWorksheet.SelectionRange.Col, grdData.CurrentWorksheet.SelectionRange.Cols)
+
+    '    Try
+    '        grdData.DoAction(removeOutlineAction)
+    '    Catch
+    '    End Try
+
+    '    If removeOutlineAction.RemovedOutline Is Nothing Then
+    '        MessageBox.Show("No grouped columns and outline found at specified position.")
+    '    End If
+    'End Sub
+
+    'Private Sub ungroupAllColumnsToolStripMenuItem_Click_1(sender As Object, e As EventArgs) Handles ungroupAllColumnsToolStripMenuItem.Click
+    '    grdData.DoAction(New unvell.ReoGrid.Actions.ClearOutlineAction(unvell.ReoGrid.RowOrColumn.Column))
+    'End Sub
+
+    'Private Sub groupRowsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles groupRowsToolStripMenuItem1.Click
+    '    Try
+    '        grdData.DoAction(New unvell.ReoGrid.Actions.AddOutlineAction(unvell.ReoGrid.RowOrColumn.Row, grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows))
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineOutOfRangeException
+    '        MessageBox.Show("Outline out of available range. The last row of spreadsheet cannot be grouped into outlines.")
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineAlreadyDefinedException
+    '        MessageBox.Show("Another same outline already exists.")
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineIntersectedException
+    '        MessageBox.Show("The outline to be added intersects with another existing one.")
+    '    Catch generatedExceptionName As unvell.ReoGrid.OutlineTooMuchException
+    '        MessageBox.Show("Level of outlines reached the maximum number of levels (10).")
+    '    End Try
+    'End Sub
+
+    'Private Sub ungroupAllRowsToolStripMenuItem_Click_1(sender As Object, e As EventArgs) Handles ungroupAllRowsToolStripMenuItem.Click
+    '    grdData.DoAction(New unvell.ReoGrid.Actions.ClearOutlineAction(unvell.ReoGrid.RowOrColumn.Row))
+    'End Sub
+
+    'Private Sub ungroupRowsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ungroupRowsToolStripMenuItem1.Click
+    '    Dim removeOutlineAction = New unvell.ReoGrid.Actions.RemoveOutlineAction(unvell.ReoGrid.RowOrColumn.Row, grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows)
+
+    '    Try
+    '        grdData.DoAction(removeOutlineAction)
+    '    Catch
+    '    End Try
+
+    '    If removeOutlineAction.RemovedOutline Is Nothing Then
+    '        MessageBox.Show("No grouped rows and outline found at specified position.")
+    '    End If
+    'End Sub
+
+    Private Sub mnuInsertRowsAfter_Click(sender As Object, e As EventArgs) Handles mnuInsertRowsAfter.Click
+        clsInsertRows.AddParameter("start_row", grdCurrSheet.RowHeaders(grdCurrSheet.SelectionRange.EndRow).Text)
+        clsInsertRows.AddParameter("number_rows", grdData.CurrentWorksheet.SelectionRange.Rows)
+        If frmMain.clsInstatOptions.bIncludeRDefaultParameters Then
+            clsInsertRows.AddParameter("before", "FALSE")
+        Else
+            clsInsertRows.RemoveParameterByName("before")
+        End If
+        frmMain.clsRLink.RunScript(clsInsertRows.ToScript(), strComment:="Right Click menu: Insert row(s) After")
+    End Sub
+
+    Private Sub mnuInsertRowsBefore_Click(sender As Object, e As EventArgs) Handles mnuInsertRowsBefore.Click
+        clsInsertRows.AddParameter("start_row", grdCurrSheet.RowHeaders(grdCurrSheet.SelectionRange.Row).Text)
+        clsInsertRows.AddParameter("number_rows", grdData.CurrentWorksheet.SelectionRange.Rows)
+        clsInsertRows.AddParameter("before", "TRUE")
+        frmMain.clsRLink.RunScript(clsInsertRows.ToScript(), strComment:="Right Click menu: Insert row(s) Before")
+    End Sub
+
+    Private Sub mnuDeleteRows_Click(sender As Object, e As EventArgs) Handles mnuDeleteRows.Click
+        Dim Delete = MsgBox("Are you sure you want to delete these row(s)?" & vbNewLine & "This action cannot be undone.", MessageBoxButtons.YesNo, "Delete Row(s)")
+        If Delete = DialogResult.Yes Then
+            clsDeleteRows.AddParameter("row_names", SelectedRows())
+            frmMain.clsRLink.RunScript(clsDeleteRows.ToScript(), strComment:="Right Click menu: Delete row(s)")
+        End If
+    End Sub
+
+    'Private Sub resetToDefaultHeightToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles resetToDefaultHeightToolStripMenuItem.Click
+    '    grdData.DoAction(New unvell.ReoGrid.Actions.SetRowsHeightAction(grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows, unvell.ReoGrid.Worksheet.InitDefaultRowHeight))
+    'End Sub
+
+    'Private Sub hideRowsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles hideRowsToolStripMenuItem.Click
+    '    grdData.DoAction(New unvell.ReoGrid.Actions.HideRowsAction(grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows))
+    'End Sub
+
+    'Private Sub unhideRowsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles unhideRowsToolStripMenuItem.Click
+    '    grdData.DoAction(New unvell.ReoGrid.Actions.UnhideRowsAction(grdData.CurrentWorksheet.SelectionRange.Row, grdData.CurrentWorksheet.SelectionRange.Rows))
+    'End Sub
+
+    'Private Sub cutRangeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles cutRangeToolStripMenuItem.Click
+    '    Try
+    '        grdData.CurrentWorksheet.Cut()
+    '    Catch generatedExceptionName As unvell.ReoGrid.RangeIntersectionException
+    '        MessageBox.Show("Cannot cut a range that Is a part Of another merged cell.")
+    '    Catch
+    '        MessageBox.Show("We can't to do that for selected range.")
+    '    End Try
+    'End Sub
+
+    Public Sub copyRange()
+        Try
+            grdData.CurrentWorksheet.Copy()
+        Catch
+            MessageBox.Show("Cannot copy the current selection.")
+        End Try
+    End Sub
+
+    'Private Sub pasteRangeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles pasteRangeToolStripMenuItem.Click
+    '    Try
+    '        grdData.CurrentWorksheet.Paste()
+    '    Catch ex As Exception
+    '        MessageBox.Show(ex.Message)
+    '    End Try
+    'End Sub
+    Public Sub selectAllText()
+        grdCurrSheet.SelectAll()
+    End Sub
+
+    Private Sub insertSheet_Click(sender As Object, e As EventArgs) Handles insertSheet.Click
+        dlgFileNew.ShowDialog()
+    End Sub
+
+    Private Sub deleteSheet_Click(sender As Object, e As EventArgs) Handles deleteSheet.Click
+        Dim strScript As String
+        Dim Delete = MsgBox("Are you sure you want to delete this dataframe?" & vbNewLine & "This action cannot be undone.", MessageBoxButtons.YesNo, "Delete Sheet")
+        If grdData.Worksheets.Count > 0 Then
+            If Delete = DialogResult.Yes Then
+                strScript = frmMain.clsRLink.strInstatDataObject & "$delete_dataframe(data_name =" & Chr(34) & grdData.CurrentWorksheet.Name & Chr(34) & ")"
+                frmMain.clsRLink.RunScript(strScript)
+            End If
+        End If
+    End Sub
+
+    Private Sub grdData_WorksheetRemoved(sender As Object, e As WorksheetRemovedEventArgs) Handles grdData.WorksheetRemoved
+        If grdData.Worksheets.Count < 1 Then
+            grdData.Hide()
+        ElseIf grdCurrSheet.Equals(e.Worksheet) Then
+            UpdateCurrentWorksheet()
+            grdData.Refresh()
+        End If
+    End Sub
+
+    Private Sub mnuColumnRename_Click(sender As Object, e As EventArgs) Handles mnuColumnRename.Click
+        dlgName.Setcurrentcolumn(SelectedColumnsAsArray()(0), grdCurrSheet.Name)
+        dlgName.ShowDialog()
+    End Sub
+
+    Private Sub grdData_CurrentWorksheetChanged(sender As Object, e As EventArgs) Handles grdData.CurrentWorksheetChanged, Me.Load, grdData.WorksheetInserted
+        UpdateCurrentWorksheet()
+    End Sub
+
+    Public Sub UpdateCurrentWorksheet()
+        grdCurrSheet = grdData.CurrentWorksheet
+        If grdCurrSheet IsNot Nothing AndAlso frmMain.clsRLink.GetDataFrameNames().Contains(grdCurrSheet.Name) Then
+            UpdateRFunctionDataFrameParameters()
+            frmMain.strCurrentDataFrame = grdCurrSheet.Name
+            frmMain.tstatus.Text = grdCurrSheet.Name
+            grdCurrSheet.SelectionForwardDirection = unvell.ReoGrid.SelectionForwardDirection.Down
+            grdCurrSheet.SetSettings(unvell.ReoGrid.WorksheetSettings.Edit_DragSelectionToMoveCells, False)
+            lblRowDisplay.Text = "Showing " & grdCurrSheet.RowCount & " rows of " & frmMain.clsRLink.GetDataFrameLength(grdCurrSheet.Name, True)
+            If frmMain.clsRLink.RunInternalScriptGetValue(clsFilterApplied.ToScript()).AsLogical(0) Then
+                lblRowDisplay.Text = lblRowDisplay.Text & " (" & frmMain.clsRLink.GetDataFrameLength(grdCurrSheet.Name, False) & ")"
+            End If
+        Else
+            frmMain.tstatus.Text = "No data loaded"
+            lblRowDisplay.Text = ""
+        End If
+    End Sub
+
+    'TODO discuss validation for cell editing
+    Private Sub grdCurrSheet_BeforeCellEdit(sender As Object, e As CellBeforeEditEventArgs) Handles grdCurrSheet.BeforeCellEdit
+        'temporary disabled editing
+        'e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_AfterCellEdit(sender As Object, e As CellAfterEditEventArgs) Handles grdCurrSheet.AfterCellEdit
+        ReplaceValueInData(e.NewData.ToString(), e.Cell.Row, e.Cell.Column)
+        e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+    End Sub
+
+    Private Sub ReplaceValueInData(strNewValue As String, iRow As Integer, iCol As Integer)
+        Dim dblValue As Double
+        Dim iValue As Integer
+        Dim lstCurrentDataColumns As String()
+        Dim strCurrentColumn As String
+        Dim clsGetVariablesMetadata As New RFunction
+        Dim clsGetFactorLevels As New RFunction
+        Dim strCellDataType As String
+        Dim chrCurrentFactorLevels As CharacterVector
+        Dim bValid As Boolean = False
+
+        clsGetFactorLevels.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_column_factor_levels")
+        clsGetFactorLevels.AddParameter("data_name", Chr(34) & grdData.CurrentWorksheet.Name & Chr(34))
+
+        clsGetVariablesMetadata.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_variables_metadata")
+        clsGetVariablesMetadata.AddParameter("data_name", Chr(34) & grdData.CurrentWorksheet.Name & Chr(34))
+        clsGetVariablesMetadata.AddParameter("property", "data_type_label")
+
+        lstCurrentDataColumns = lstColumnNames.Find(Function(x) x.Key = grdData.CurrentWorksheet.Name).Value
+        strCurrentColumn = lstCurrentDataColumns(iCol)
+
+        clsGetVariablesMetadata.AddParameter("column", Chr(34) & strCurrentColumn & Chr(34))
+        clsGetFactorLevels.AddParameter("col_name", Chr(34) & strCurrentColumn & Chr(34))
+        strCellDataType = frmMain.clsRLink.RunInternalScriptGetValue(clsGetVariablesMetadata.ToScript()).AsCharacter(0)
+
+        clsReplaceValue.AddParameter("col_name", Chr(34) & strCurrentColumn & Chr(34))
+        clsReplaceValue.AddParameter("rows", Chr(34) & grdCurrSheet.RowHeaders.Item(iRow).Text & Chr(34))
+
+        If strNewValue = "NA" Then
+            clsReplaceValue.AddParameter("new_value", strNewValue)
+            bValid = True
+        Else
+            Select Case strCellDataType
+                Case "factor"
+                    chrCurrentFactorLevels = frmMain.clsRLink.RunInternalScriptGetValue(clsGetFactorLevels.ToScript()).AsCharacter
+                    If Not chrCurrentFactorLevels.Contains(strNewValue) Then
+                        MsgBox("Invalid value: " & strNewValue & vbNewLine & "This column is: factor. Values must be an existing level of this factor column.", MsgBoxStyle.Exclamation, "Invalid Value")
+                    Else
+                        clsReplaceValue.AddParameter("new_value", Chr(34) & strNewValue & Chr(34))
+                        bValid = True
+                    End If
+                Case "numeric"
+                    If Double.TryParse(strNewValue, dblValue) Then
+                        clsReplaceValue.AddParameter("new_value", strNewValue)
+                        bValid = True
+                    Else
+                        MsgBox("Invalid value: " & strNewValue & vbNewLine & "This column is: numeric. Values must be numeric.", MsgBoxStyle.Exclamation, "Invalid Value")
+                    End If
+                Case "integer"
+                    If Integer.TryParse(strNewValue, iValue) Then
+                        clsReplaceValue.AddParameter("new_value", strNewValue)
+                        bValid = True
+                    Else
+                        MsgBox("Invalid value: " & strNewValue & vbNewLine & "This column is: integer. Values must be integer.", MsgBoxStyle.Exclamation, "Invalid Value")
+                    End If
+                    'Currently removed as this is the class for a blank column
+                    'Case "logical"
+                    '    'Should we accept 'true'/'false'/'True' etc. as logical values?
+                    '    If e.NewData = "TRUE" OrElse e.NewData = "FALSE" Then
+                    '        clsReplaceValue.AddParameter("new_value", e.NewData)
+                    '        bValid = True
+                    '    Else
+                    '        MsgBox("Invalid value: " & e.NewData.ToString() & vbNewLine & "This column is: logical. Values must be logical (either TRUE or FALSE).", MsgBoxStyle.Exclamation, "Invalid Value")
+                    '        e.EndReason = unvell.ReoGrid.EndEditReason.Cancel
+                    '    End If
+                    'Case "character"
+                    'clsReplaceValue.AddParameter("new_value", Chr(34) & e.NewData & Chr(34))
+                    'bValid = True
+                Case Else
+                    If Double.TryParse(strNewValue, dblValue) OrElse strNewValue = "TRUE" OrElse strNewValue = "FALSE" Then
+                        clsReplaceValue.AddParameter("new_value", strNewValue)
+                    Else
+                        clsReplaceValue.AddParameter("new_value", Chr(34) & strNewValue & Chr(34))
+                    End If
+                    bValid = True
+            End Select
+        End If
+
+        If bValid Then
+            frmMain.clsRLink.RunScript(clsReplaceValue.ToScript(), strComment:="Replace Value in Data")
+        End If
+    End Sub
+
+    Private Sub renameSheet_Click(sender As Object, e As EventArgs) Handles renameSheet.Click
+        dlgRenameSheet.ShowDialog()
+    End Sub
+
+    Private Sub MoveOrCopySheet_Click(sender As Object, e As EventArgs) Handles CopySheet.Click
+        dlgCopySheet.ShowDialog()
+    End Sub
+
+    Private Sub mnuConvertVariate_Click(sender As Object, e As EventArgs) Handles mnuConvertVariate.Click
+        clsConvertTo.AddParameter("to_type", Chr(34) & "numeric" & Chr(34))
+        clsConvertTo.AddParameter("col_names", SelectedColumns())
+        frmMain.clsRLink.RunScript(clsConvertTo.ToScript(), strComment:="Right click menu: Convert Column(s) To Numeric")
+    End Sub
+
+    Private Sub mnuConvertText_Click(sender As Object, e As EventArgs) Handles mnuConvertText.Click
+        clsConvertTo.AddParameter("to_type", Chr(34) & "character" & Chr(34))
+        clsConvertTo.AddParameter("col_names", SelectedColumns())
+        frmMain.clsRLink.RunScript(clsConvertTo.ToScript(), strComment:="Right click menu: Convert Column(s) To Character")
+    End Sub
+
+    Private Sub mnuConvertToFactor_Click(sender As Object, e As EventArgs) Handles mnuConvertToFactor.Click
+        clsConvertTo.AddParameter("to_type", Chr(34) & "factor" & Chr(34))
+        clsConvertTo.AddParameter("col_names", SelectedColumns())
+        frmMain.clsRLink.RunScript(clsConvertTo.ToScript(), strComment:="Right click menu: Convert Column(s) To Factor")
+    End Sub
+
+    Private Function SelectedColumns(Optional bWithQuotes As Boolean = True) As String
+        Dim lstSelectedColumns As New List(Of String)
+        Dim strCols As String = ""
+        Dim lstCurrentDataColumns As String()
+
+        lstCurrentDataColumns = lstColumnNames.Find(Function(x) x.Key = grdData.CurrentWorksheet.Name).Value
+
+        If lstCurrentDataColumns IsNot Nothing AndAlso lstCurrentDataColumns.Count > 0 Then
+            For i As Integer = grdData.CurrentWorksheet.SelectionRange.Col To grdData.CurrentWorksheet.SelectionRange.Col + grdData.CurrentWorksheet.SelectionRange.Cols - 1
+                lstSelectedColumns.Add(lstCurrentDataColumns(i))
+            Next
+
+            strCols = "c("
+            For j As Integer = 0 To lstSelectedColumns.Count - 1
+                If j > 0 Then
+                    strCols = strCols & ","
+                End If
+                If bWithQuotes Then
+                    strCols = strCols & Chr(34) & lstSelectedColumns(j) & Chr(34)
+                Else
+                    strCols = strCols & lstSelectedColumns(j)
+                End If
+            Next
+            strCols = strCols & ")"
+        End If
+        Return strCols
+    End Function
+
+    Private Function SelectedRows(Optional bWithQuotes As Boolean = True) As String
+        Dim lstSelectedRows As New List(Of String)
+        Dim strRows As String = ""
+
+        For i As Integer = grdData.CurrentWorksheet.SelectionRange.Row To grdData.CurrentWorksheet.SelectionRange.Row + grdData.CurrentWorksheet.SelectionRange.Rows - 1
+            lstSelectedRows.Add(grdCurrSheet.RowHeaders.Item(i).Text)
+        Next
+        strRows = "c("
+        For j As Integer = 0 To lstSelectedRows.Count - 1
+            If j > 0 Then
+                strRows = strRows & ","
+            End If
+            If bWithQuotes Then
+                strRows = strRows & Chr(34) & lstSelectedRows(j) & Chr(34)
+            Else
+                strRows = strRows & lstSelectedRows(j)
+            End If
+        Next
+        strRows = strRows & ")"
+        Return strRows
+    End Function
+
+    Private Function SelectedColumnsAsArray() As String()
+        Dim strSelectedColumns As String()
+        Dim lstCurrentDataColumns As String()
+
+        lstCurrentDataColumns = lstColumnNames.Find(Function(x) x.Key = grdData.CurrentWorksheet.Name).Value
+
+        If lstColumnNames IsNot Nothing AndAlso lstColumnNames.Count > 0 Then
+            strSelectedColumns = New String(grdData.CurrentWorksheet.SelectionRange.Cols - 1) {}
+            For i As Integer = 0 To grdData.CurrentWorksheet.SelectionRange.Cols - 1
+                strSelectedColumns(i) = lstCurrentDataColumns(i + grdData.CurrentWorksheet.SelectionRange.Col)
+            Next
+            Return strSelectedColumns
+        Else
+            strSelectedColumns = New String() {}
+        End If
+        Return strSelectedColumns
+    End Function
+
+    Private Function SelectedColumnPosition(bFirstNotLast As Boolean)
+        Dim lstCurrentDataColumns As String()
+
+        lstCurrentDataColumns = lstColumnNames.Find(Function(x) x.Key = grdData.CurrentWorksheet.Name).Value
+        If bFirstNotLast Then
+            Return Chr(34) & lstCurrentDataColumns(grdData.CurrentWorksheet.SelectionRange.Col) & Chr(34)
+        Else
+            Return Chr(34) & lstCurrentDataColumns(grdData.CurrentWorksheet.SelectionRange.EndCol) & Chr(34)
+        End If
+    End Function
+
+    Private Sub columnFilterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles columnFilterToolStripMenuItem.Click
+        dlgRestrict.bIsSubsetDialog = False
+        dlgRestrict.strDefaultDataframe = grdCurrSheet.Name
+        dlgRestrict.ShowDialog()
+    End Sub
+
+    Private Sub reorderSheet_Click(sender As Object, e As EventArgs) Handles reorderSheet.Click
+        dlgReorderSheet.ShowDialog()
+    End Sub
+
+    Private Sub UpdateRFunctionDataFrameParameters()
+        If grdCurrSheet IsNot Nothing Then
+            clsAppendVariablesMetaData.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsColumnNames.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsInsertColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsDeleteColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsConvertTo.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsInsertRows.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsDeleteRows.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsUnhideAllColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsReplaceValue.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsRemoveFilter.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsFreezeColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsUnfreezeColumns.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsGetDataFrame.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsConvertOrderedFactor.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+            clsFilterApplied.AddParameter("data_name", Chr(34) & grdCurrSheet.Name & Chr(34))
+        End If
+    End Sub
+
+    Public Sub SetColumnNames(strDataFrameName As String, strColumnNames As String())
+        Dim iIndex As Integer
+        iIndex = lstColumnNames.FindIndex(Function(x) x.Key = strDataFrameName)
+        If iIndex <> -1 Then
+            lstColumnNames.RemoveAt(iIndex)
+        End If
+        lstColumnNames.Add(New KeyValuePair(Of String, String())(strDataFrameName, strColumnNames))
+    End Sub
+
+    Private Sub mnuFilter_Click(sender As Object, e As EventArgs) Handles mnuFilter.Click
+        dlgRestrict.bIsSubsetDialog = False
+        dlgRestrict.strDefaultDataframe = grdCurrSheet.Name
+        dlgRestrict.ShowDialog()
+    End Sub
+
+    Private Sub mnuRemoveCurrentFilter_Click(sender As Object, e As EventArgs) Handles mnuRemoveCurrentFilter.Click
+        frmMain.clsRLink.RunScript(clsRemoveFilter.ToScript(), strComment:="Right click menu: Remove Current Filter")
+    End Sub
+
+    Private Sub clearColumnFilterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles clearColumnFilterToolStripMenuItem.Click
+        frmMain.clsRLink.RunScript(clsRemoveFilter.ToScript(), strComment:="Right click menu: Remove Current Filter")
+    End Sub
+
+    Private Sub SortToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles SortToolStripMenuItem.Click
+        dlgSort.ShowDialog()
+    End Sub
+
+    Private Sub FreezeToHereToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles FreezeToHereToolStripMenuItem.Click
+        Dim strLastSelectedColumn As String
+        Dim strSelectedColumns As String()
+
+        strSelectedColumns = SelectedColumnsAsArray()
+        If strSelectedColumns.Length <> 0 Then
+            strLastSelectedColumn = strSelectedColumns(strSelectedColumns.Length - 1)
+            clsFreezeColumns.AddParameter("column", Chr(34) & strLastSelectedColumn & Chr(34))
+            frmMain.clsRLink.RunScript(clsFreezeColumns.ToScript(), strComment:="Right click menu: Freeze columns")
+        End If
+    End Sub
+
+    Private Sub UnfreezeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UnfreezeToolStripMenuItem.Click
+        frmMain.clsRLink.RunScript(clsUnfreezeColumns.ToScript(), strComment:="Right click menu: Freeze columns")
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCut(sender As Object, e As BeforeRangeOperationEventArgs) Handles grdCurrSheet.BeforeCut
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_BeforePaste(sender As Object, e As BeforeRangeOperationEventArgs) Handles grdCurrSheet.BeforePaste
+        e.IsCancelled = True
+        If Not e.Range.IsSingleCell Then
+            MsgBox("Pasting multiple cells is currently disabled. This feature will be included in future versions." & vbNewLine & "Try pasting one cell at a time.", MsgBoxStyle.Information, "Cannot paste multiple cells")
+        Else
+            ReplaceValueInData(Clipboard.GetText(), e.Range.Row, e.Range.Col)
+        End If
+    End Sub
+
+    ' Not currently working. Bug with reogrid reported here:
+    ' https://reogrid.net/forum/viewtopic.php?id=350
+    Private Sub grdCurrSheet_BeforeRangeMove(sender As Object, e As BeforeCopyOrMoveRangeEventArgs) Handles grdCurrSheet.BeforeRangeMove
+        e.IsCancelled = True
+    End Sub
+
+    Private Sub grdCurrSheet_BeforeCellKeyDown(sender As Object, e As BeforeCellKeyDownEventArgs) Handles grdCurrSheet.BeforeCellKeyDown
+        If e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Delete OrElse e.KeyCode = unvell.ReoGrid.Interaction.KeyCode.Back Then
+            MsgBox("Deleting cells is currently disabled. This feature will be included in future versions." & vbNewLine & "To remove a cell's value, replace the value with NA.", MsgBoxStyle.Information, "Cannot delete cells.")
+            e.IsCancelled = True
+        End If
+    End Sub
+
+    Private Sub mnuConvert_Click(sender As Object, e As EventArgs) Handles mnuConvert.Click
+        'TODO Selected column should automatically appear in dialog
+        dlgConvertColumns.ShowDialog()
+    End Sub
+
+    Private Sub copyRangeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles copyRangeToolStripMenuItem.Click
+        grdData.CurrentWorksheet.Copy()
+    End Sub
+
+    Private Sub ViewSheet_Click(sender As Object, e As EventArgs) Handles ViewSheet.Click
+        clsViewDataFrame.AddParameter("x", clsRFunctionParameter:=clsGetDataFrame)
+        clsViewDataFrame.AddParameter("title", Chr(34) & grdCurrSheet.Name & Chr(34))
+        frmMain.clsRLink.RunScript(clsViewDataFrame.ToScript, strComment:="Right Click Menu: View R Data Frame")
+    End Sub
+
+    Private Sub mnuConvertDate_Click(sender As Object, e As EventArgs) Handles mnuConvertToDate.Click
+        dlgMakeDate.SetCurrentColumn(SelectedColumnsAsArray()(0), grdCurrSheet.Name)
+        dlgMakeDate.ShowDialog()
+    End Sub
+
+    Private Sub mnuCovertToOrderedFactors_Click(sender As Object, e As EventArgs) Handles mnuCovertToOrderedFactors.Click
+        clsConvertOrderedFactor.AddParameter("col_names", SelectedColumns())
+        clsConvertOrderedFactor.AddParameter("to_type", Chr(34) & "ordered_factor" & Chr(34))
+        frmMain.clsRLink.RunScript(clsConvertOrderedFactor.ToScript, strComment:="Right Click Menu: Convert to Ordered Factor")
+    End Sub
+
+    Private Sub mnuDuplicateColumn_Click(sender As Object, e As EventArgs) Handles mnuDuplicateColumn.Click
+        dlgDuplicateColumns.SetCurrentColumn(SelectedColumnsAsArray()(0), grdCurrSheet.Name)
+        dlgDuplicateColumns.ShowDialog()
+    End Sub
+
+    Private Sub mnuAddComment_Click(sender As Object, e As EventArgs) Handles mnuAddComment.Click
+        dlgAddComment.ShowDialog()
+    End Sub
+
+    Private Sub AddCommentToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles AddComment.Click
+        dlgAddComment.SetCurrentColumn(SelectedColumnsAsArray()(0), grdCurrSheet.Name)
+        dlgAddComment.ShowDialog()
+    End Sub
+End Class

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -265,7 +265,7 @@ Public Class ucrDataView
     '    End Try
     'End Sub
 
-    Public Sub copyRange()
+    Public Sub CopyRange()
         Try
             grdData.CurrentWorksheet.Copy()
         Catch
@@ -280,8 +280,10 @@ Public Class ucrDataView
     '        MessageBox.Show(ex.Message)
     '    End Try
     'End Sub
-    Public Sub selectAllText()
-        grdCurrSheet.SelectAll()
+    Public Sub SelectAllText()
+        If grdCurrSheet IsNot Nothing Then
+            grdCurrSheet.SelectAll()
+        End If
     End Sub
 
     Private Sub insertSheet_Click(sender As Object, e As EventArgs) Handles insertSheet.Click

--- a/instat/ucrLog.Designer.vb
+++ b/instat/ucrLog.Designer.vb
@@ -23,32 +23,49 @@ Partial Class ucrLog
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.txtLog = New System.Windows.Forms.TextBox()
+        Me.lblHeader = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'txtLog
         '
-        Me.txtLog.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.txtLog.Location = New System.Drawing.Point(0, 0)
+        Me.txtLog.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.txtLog.Location = New System.Drawing.Point(0, 20)
         Me.txtLog.Multiline = True
         Me.txtLog.Name = "txtLog"
         Me.txtLog.ReadOnly = True
         Me.txtLog.ScrollBars = System.Windows.Forms.ScrollBars.Both
-        Me.txtLog.Size = New System.Drawing.Size(531, 415)
+        Me.txtLog.Size = New System.Drawing.Size(531, 395)
         Me.txtLog.TabIndex = 0
         Me.txtLog.TabStop = False
         '
-        'frmLog
+        'lblHeader
+        '
+        Me.lblHeader.BackColor = System.Drawing.Color.Green
+        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeader.Location = New System.Drawing.Point(0, 0)
+        Me.lblHeader.Name = "lblHeader"
+        Me.lblHeader.Size = New System.Drawing.Size(531, 20)
+        Me.lblHeader.TabIndex = 8
+        Me.lblHeader.Text = "Log"
+        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'ucrLog
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(531, 415)
+        Me.Controls.Add(Me.lblHeader)
         Me.Controls.Add(Me.txtLog)
         Me.Name = "ucrLog"
-        Me.Text = "Log Window"
+        Me.Size = New System.Drawing.Size(531, 415)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
     End Sub
 
     Friend WithEvents txtLog As TextBox
+    Friend WithEvents lblHeader As Label
 End Class

--- a/instat/ucrLog.Designer.vb
+++ b/instat/ucrLog.Designer.vb
@@ -1,0 +1,54 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrLog
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.txtLog = New System.Windows.Forms.TextBox()
+        Me.SuspendLayout()
+        '
+        'txtLog
+        '
+        Me.txtLog.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.txtLog.Location = New System.Drawing.Point(0, 0)
+        Me.txtLog.Multiline = True
+        Me.txtLog.Name = "txtLog"
+        Me.txtLog.ReadOnly = True
+        Me.txtLog.ScrollBars = System.Windows.Forms.ScrollBars.Both
+        Me.txtLog.Size = New System.Drawing.Size(531, 415)
+        Me.txtLog.TabIndex = 0
+        Me.txtLog.TabStop = False
+        '
+        'frmLog
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(531, 415)
+        Me.Controls.Add(Me.txtLog)
+        Me.Name = "ucrLog"
+        Me.Text = "Log Window"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents txtLog As TextBox
+End Class

--- a/instat/ucrLog.resx
+++ b/instat/ucrLog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/ucrLog.vb
+++ b/instat/ucrLog.vb
@@ -1,0 +1,25 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Public Class ucrLog
+    Public Sub CopyText()
+        txtLog.Copy()
+    End Sub
+
+    Public Sub SelectAllText()
+        txtLog.SelectAll()
+    End Sub
+End Class

--- a/instat/ucrOutputWindow.Designer.vb
+++ b/instat/ucrOutputWindow.Designer.vb
@@ -28,16 +28,19 @@ Partial Class ucrOutputWindow
         Me.mnuContextRTB = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyRTB = New System.Windows.Forms.ToolStripMenuItem()
         Me.CopyImageRTB = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblHeader = New System.Windows.Forms.Label()
         Me.mnuContextRTB.SuspendLayout()
         Me.SuspendLayout()
         '
         'ucrWPFrtfElementHost
         '
+        Me.ucrWPFrtfElementHost.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.ucrWPFrtfElementHost.ContextMenuStrip = Me.mnuContextRTB
-        Me.ucrWPFrtfElementHost.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.ucrWPFrtfElementHost.Location = New System.Drawing.Point(0, 0)
+        Me.ucrWPFrtfElementHost.Location = New System.Drawing.Point(0, 20)
         Me.ucrWPFrtfElementHost.Name = "ucrWPFrtfElementHost"
-        Me.ucrWPFrtfElementHost.Size = New System.Drawing.Size(722, 262)
+        Me.ucrWPFrtfElementHost.Size = New System.Drawing.Size(722, 242)
         Me.ucrWPFrtfElementHost.TabIndex = 0
         Me.ucrWPFrtfElementHost.Text = "ucrWPFrtfElementHost"
         Me.ucrWPFrtfElementHost.Child = Me.ucrRichTextBox
@@ -46,29 +49,42 @@ Partial Class ucrOutputWindow
         '
         Me.mnuContextRTB.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyRTB, Me.CopyImageRTB})
         Me.mnuContextRTB.Name = "mnuContextRTB"
-        Me.mnuContextRTB.Size = New System.Drawing.Size(151, 48)
+        Me.mnuContextRTB.Size = New System.Drawing.Size(150, 48)
         '
         'CopyRTB
         '
         Me.CopyRTB.Name = "CopyRTB"
-        Me.CopyRTB.Size = New System.Drawing.Size(150, 22)
+        Me.CopyRTB.Size = New System.Drawing.Size(149, 22)
         Me.CopyRTB.Text = "Copy RichText"
         '
         'CopyImageRTB
         '
         Me.CopyImageRTB.Enabled = False
         Me.CopyImageRTB.Name = "CopyImageRTB"
-        Me.CopyImageRTB.Size = New System.Drawing.Size(150, 22)
+        Me.CopyImageRTB.Size = New System.Drawing.Size(149, 22)
         Me.CopyImageRTB.Text = "Copy Image"
         '
-        'frmOutputWindow
+        'lblHeader
+        '
+        Me.lblHeader.BackColor = System.Drawing.Color.Green
+        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeader.Location = New System.Drawing.Point(0, 0)
+        Me.lblHeader.Name = "lblHeader"
+        Me.lblHeader.Size = New System.Drawing.Size(722, 20)
+        Me.lblHeader.TabIndex = 6
+        Me.lblHeader.Text = "Output Window"
+        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
+        'ucrOutputWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(722, 262)
+        Me.Controls.Add(Me.lblHeader)
         Me.Controls.Add(Me.ucrWPFrtfElementHost)
         Me.Name = "ucrOutputWindow"
-        Me.Text = "Output Window"
+        Me.Size = New System.Drawing.Size(722, 262)
         Me.mnuContextRTB.ResumeLayout(False)
         Me.ResumeLayout(False)
 
@@ -79,4 +95,5 @@ Partial Class ucrOutputWindow
     Friend WithEvents mnuContextRTB As ContextMenuStrip
     Friend WithEvents CopyRTB As ToolStripMenuItem
     Friend WithEvents CopyImageRTB As ToolStripMenuItem
+    Friend WithEvents lblHeader As Label
 End Class

--- a/instat/ucrOutputWindow.Designer.vb
+++ b/instat/ucrOutputWindow.Designer.vb
@@ -1,0 +1,82 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrOutputWindow
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
+        Me.ucrWPFrtfElementHost = New System.Windows.Forms.Integration.ElementHost()
+        Me.ucrRichTextBox = New instat.ucrWPFRichTextBox()
+        Me.mnuContextRTB = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.CopyRTB = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CopyImageRTB = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuContextRTB.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'ucrWPFrtfElementHost
+        '
+        Me.ucrWPFrtfElementHost.ContextMenuStrip = Me.mnuContextRTB
+        Me.ucrWPFrtfElementHost.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrWPFrtfElementHost.Location = New System.Drawing.Point(0, 0)
+        Me.ucrWPFrtfElementHost.Name = "ucrWPFrtfElementHost"
+        Me.ucrWPFrtfElementHost.Size = New System.Drawing.Size(722, 262)
+        Me.ucrWPFrtfElementHost.TabIndex = 0
+        Me.ucrWPFrtfElementHost.Text = "ucrWPFrtfElementHost"
+        Me.ucrWPFrtfElementHost.Child = Me.ucrRichTextBox
+        '
+        'mnuContextRTB
+        '
+        Me.mnuContextRTB.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyRTB, Me.CopyImageRTB})
+        Me.mnuContextRTB.Name = "mnuContextRTB"
+        Me.mnuContextRTB.Size = New System.Drawing.Size(151, 48)
+        '
+        'CopyRTB
+        '
+        Me.CopyRTB.Name = "CopyRTB"
+        Me.CopyRTB.Size = New System.Drawing.Size(150, 22)
+        Me.CopyRTB.Text = "Copy RichText"
+        '
+        'CopyImageRTB
+        '
+        Me.CopyImageRTB.Enabled = False
+        Me.CopyImageRTB.Name = "CopyImageRTB"
+        Me.CopyImageRTB.Size = New System.Drawing.Size(150, 22)
+        Me.CopyImageRTB.Text = "Copy Image"
+        '
+        'frmOutputWindow
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(722, 262)
+        Me.Controls.Add(Me.ucrWPFrtfElementHost)
+        Me.Name = "ucrOutputWindow"
+        Me.Text = "Output Window"
+        Me.mnuContextRTB.ResumeLayout(False)
+        Me.ResumeLayout(False)
+
+    End Sub
+
+    Friend WithEvents ucrWPFrtfElementHost As Integration.ElementHost
+    Friend ucrRichTextBox As ucrWPFRichTextBox
+    Friend WithEvents mnuContextRTB As ContextMenuStrip
+    Friend WithEvents CopyRTB As ToolStripMenuItem
+    Friend WithEvents CopyImageRTB As ToolStripMenuItem
+End Class

--- a/instat/ucrOutputWindow.resx
+++ b/instat/ucrOutputWindow.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="mnuContextRTB.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/instat/ucrOutputWindow.vb
+++ b/instat/ucrOutputWindow.vb
@@ -1,0 +1,92 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports System.ComponentModel
+Imports System.Globalization
+Imports System.Threading
+Imports instat.Translations
+
+Public Class ucrOutputWindow
+    'TEST temporary
+    Private Sub ucrOutputWindow_Load(sender As Object, e As EventArgs) Handles Me.Load
+        'autoTranslate(Me)
+    End Sub
+
+    'Protected Overrides Sub OnFormClosing(ByVal e As FormClosingEventArgs)
+    '    MyBase.OnFormClosing(e)
+    '    If Not e.Cancel AndAlso e.CloseReason = CloseReason.UserClosing Then
+    '        e.Cancel = True
+    '        Me.Hide()
+    '    End If
+    'End Sub
+
+    Private Sub CopyRTB_Click(sender As Object, e As EventArgs) Handles CopyRTB.Click
+        CopyContent()
+    End Sub
+
+    Public Sub CopyContent()
+        'copies the content of the selection in rich text format.
+        ucrRichTextBox.rtbOutput.Copy() 'Warning: Copy is a text method, only copies text...
+        'Using stream As New IO.MemoryStream
+        'Range = New Windows.Documents.TextRange(ucrRichTextBox.rtbOutput.Document.ContentStart, ucrRichTextBox.rtbOutput.Document.ContentEnd)
+        'Range.Save(stream, Windows.DataFormats.XamlPackage)
+        'Clipboard.SetData(DataFormats.Rtf, System.Text.Encoding.UTF8.GetString(stream.ToArray()))
+        'stream.Close()
+        'End Using
+    End Sub
+
+    Public Sub selectAllText()
+        ucrRichTextBox.rtbOutput.SelectAll()
+    End Sub
+
+    Private Sub mnuContextRTB_Opening(sender As Object, e As CancelEventArgs) Handles mnuContextRTB.Opening
+        'This sub checks whether or not Copy Image should be enabled. It is enabled if one of the selected block is an "1 image paragraph".
+        'Could add SaveImageRTB enabled when it exists.
+        For Each block As Windows.Documents.Block In ucrRichTextBox.rtbOutput.Document.Blocks
+            If ucrRichTextBox.rtbOutput.Selection.Contains(block.ContentStart) AndAlso ucrRichTextBox.rtbOutput.Selection.Contains(block.ContentEnd) AndAlso TypeOf (block) Is Windows.Documents.Paragraph AndAlso CType(block, Windows.Documents.Paragraph).Inlines.Count = 1 AndAlso TypeOf (CType(block, Windows.Documents.Paragraph).Inlines.FirstInline) Is Windows.Documents.InlineUIContainer Then
+                CopyImageRTB.Enabled = True
+                Exit Sub
+            End If
+        Next
+        CopyImageRTB.Enabled = False
+    End Sub
+
+    'Private Function RtfToImage(ByVal strRtf As String) As Image
+    ''Load RTF Document
+    'Dim file As IO.File
+    'Save to Image
+    'Dim image As Image = document.SaveToImages(0, ImageType.Bitmap)
+    'image.FromStream(stream)
+    'image.Save(“RTF2Image.jpg”, ImageFormat.Jpeg)
+    'System.Diagnostics.Process.Start(“RTF2Image.jpg)
+    'End Function
+
+    Private Sub CopyImageRTB_Click(sender As Object, e As EventArgs) Handles CopyImageRTB.Click
+        'Copies the first selected image into the clipboard.
+        Dim prphTemp As Windows.Documents.Paragraph
+        Dim conImage As Windows.Documents.InlineUIContainer
+        For Each block As Windows.Documents.Block In ucrRichTextBox.rtbOutput.Document.Blocks
+            If TypeOf (block) Is Windows.Documents.Paragraph Then
+                prphTemp = block
+                If ucrRichTextBox.rtbOutput.Selection.Contains(block.ContentStart) AndAlso prphTemp.Inlines.Count = 1 AndAlso TypeOf (prphTemp.Inlines.FirstInline) Is Windows.Documents.InlineUIContainer Then
+                    conImage = prphTemp.Inlines.FirstInline
+                    ucrRichTextBox.CopyUIElementToClipboard(conImage.Child)
+                    Exit Sub
+                End If
+            End If
+        Next
+    End Sub
+End Class

--- a/instat/ucrOutputWindow.vb
+++ b/instat/ucrOutputWindow.vb
@@ -48,7 +48,7 @@ Public Class ucrOutputWindow
         'End Using
     End Sub
 
-    Public Sub selectAllText()
+    Public Sub SelectAllText()
         ucrRichTextBox.rtbOutput.SelectAll()
     End Sub
 

--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -24,6 +24,7 @@ Partial Class ucrScript
     Private Sub InitializeComponent()
         Me.txtScript = New System.Windows.Forms.TextBox()
         Me.cmdClear = New System.Windows.Forms.Button()
+        Me.lblHeader = New System.Windows.Forms.Label()
         Me.SuspendLayout()
         '
         'txtScript
@@ -32,28 +33,42 @@ Partial Class ucrScript
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.txtScript.BorderStyle = System.Windows.Forms.BorderStyle.None
-        Me.txtScript.Location = New System.Drawing.Point(0, 24)
+        Me.txtScript.Location = New System.Drawing.Point(0, 44)
         Me.txtScript.Multiline = True
         Me.txtScript.Name = "txtScript"
         Me.txtScript.ReadOnly = True
-        Me.txtScript.Size = New System.Drawing.Size(411, 287)
+        Me.txtScript.Size = New System.Drawing.Size(411, 267)
         Me.txtScript.TabIndex = 0
         '
         'cmdClear
         '
         Me.cmdClear.Dock = System.Windows.Forms.DockStyle.Top
-        Me.cmdClear.Location = New System.Drawing.Point(0, 0)
+        Me.cmdClear.Location = New System.Drawing.Point(0, 20)
         Me.cmdClear.Name = "cmdClear"
         Me.cmdClear.Size = New System.Drawing.Size(411, 26)
         Me.cmdClear.TabIndex = 1
         Me.cmdClear.Text = "Clear contents"
         Me.cmdClear.UseVisualStyleBackColor = True
         '
+        'lblHeader
+        '
+        Me.lblHeader.BackColor = System.Drawing.Color.Green
+        Me.lblHeader.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblHeader.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.lblHeader.ForeColor = System.Drawing.SystemColors.Control
+        Me.lblHeader.Location = New System.Drawing.Point(0, 0)
+        Me.lblHeader.Name = "lblHeader"
+        Me.lblHeader.Size = New System.Drawing.Size(411, 20)
+        Me.lblHeader.TabIndex = 8
+        Me.lblHeader.Text = "Script"
+        Me.lblHeader.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
         'ucrScript
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.Controls.Add(Me.cmdClear)
+        Me.Controls.Add(Me.lblHeader)
         Me.Controls.Add(Me.txtScript)
         Me.Name = "ucrScript"
         Me.Size = New System.Drawing.Size(411, 314)
@@ -65,4 +80,5 @@ Partial Class ucrScript
 
     Friend WithEvents txtScript As TextBox
     Friend WithEvents cmdClear As Button
+    Friend WithEvents lblHeader As Label
 End Class

--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -1,0 +1,68 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrScript
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.txtScript = New System.Windows.Forms.TextBox()
+        Me.cmdClear = New System.Windows.Forms.Button()
+        Me.SuspendLayout()
+        '
+        'txtScript
+        '
+        Me.txtScript.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.txtScript.BorderStyle = System.Windows.Forms.BorderStyle.None
+        Me.txtScript.Location = New System.Drawing.Point(0, 24)
+        Me.txtScript.Multiline = True
+        Me.txtScript.Name = "txtScript"
+        Me.txtScript.ReadOnly = True
+        Me.txtScript.Size = New System.Drawing.Size(411, 287)
+        Me.txtScript.TabIndex = 0
+        '
+        'cmdClear
+        '
+        Me.cmdClear.Dock = System.Windows.Forms.DockStyle.Top
+        Me.cmdClear.Location = New System.Drawing.Point(0, 0)
+        Me.cmdClear.Name = "cmdClear"
+        Me.cmdClear.Size = New System.Drawing.Size(411, 26)
+        Me.cmdClear.TabIndex = 1
+        Me.cmdClear.Text = "Clear contents"
+        Me.cmdClear.UseVisualStyleBackColor = True
+        '
+        'ucrScript
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.cmdClear)
+        Me.Controls.Add(Me.txtScript)
+        Me.Name = "ucrScript"
+        Me.Size = New System.Drawing.Size(411, 314)
+        Me.Tag = "Script_Window"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents txtScript As TextBox
+    Friend WithEvents cmdClear As Button
+End Class

--- a/instat/ucrScript.resx
+++ b/instat/ucrScript.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -1,0 +1,39 @@
+﻿' Instat-R
+' Copyright (C) 2015
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License k
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Public Class ucrScript
+    Public Sub CopyText()
+        txtScript.Copy()
+    End Sub
+
+    Public Sub SelectAllText()
+        txtScript.SelectAll()
+    End Sub
+
+    Private Sub cmdClear_Click(sender As Object, e As EventArgs) Handles cmdClear.Click
+        Dim dlgResponse As DialogResult
+        If txtScript.Text <> "" Then
+            dlgResponse = MessageBox.Show("Are you sure you want to clear the " & Me.Text, "Clear " & Me.Text, MessageBoxButtons.YesNo)
+            If dlgResponse = DialogResult.Yes Then
+                txtScript.Clear()
+            End If
+        End If
+    End Sub
+
+    Public Sub AppendText(strText As String)
+        txtScript.Text = txtScript.Text & vbCrLf & strText
+    End Sub
+End Class


### PR DESCRIPTION
@africanmathsinitiative/instat Here is a suggested change to the frmMain layout - partly prompted by the difficultly we saw students had with the mdi child form system. This uses split containers to keep sections of the form separate while still allowing flexibility in resizing.

Please make a copy of this branch and play around and test. Let me know what you think, whether it is an improvement and any suggestions.